### PR TITLE
feat: Add Carátula container and improve Sinóptico layout

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -1416,8 +1416,9 @@ function runFlujogramaLogic() {
 
 function renderSinopticoLayout() {
     return `
+        <div id="caratula-container" class="mb-6"></div>
         <div id="sinoptico-layout-container">
-            <main id="sinoptico-main-view" class="overflow-y-auto custom-scrollbar bg-white p-6 rounded-xl shadow-lg">
+            <div id="sinoptico-main-view" class="overflow-y-auto custom-scrollbar bg-white p-6 rounded-xl shadow-lg">
                 <div class="flex flex-col md:flex-row gap-4 mb-4">
                     <div class="relative flex-grow">
                         <i data-lucide="search" class="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-slate-400"></i>
@@ -1445,7 +1446,7 @@ function renderSinopticoLayout() {
                     </div>
                 </div>
                 <ul id="sinoptico-tree-container" class="sinoptico-tree-container"></ul>
-            </main>
+            </div>
             <div id="sinoptico-details-container">
                 <aside id="sinoptico-details-panel">
                     <div id="detail-container" class="sinoptico-sidebar-sticky">

--- a/public/style.css
+++ b/public/style.css
@@ -91,3 +91,16 @@ body { font-family: 'Inter', sans-serif; background-color: #f1f5f9; color: #1e29
 .sinoptico-tree-container ul > li + li {
   margin-top: 8px; /* Ajusta este valor (ej. 5px, 10px) según tu preferencia */
 }
+
+/* --- VISTA SINÓPTICA MEJORADA --- */
+#sinoptico-layout-container {
+    display: flex;
+    gap: 1.5rem; /* 24px */
+    height: calc(100vh - 8rem);
+}
+#sinoptico-main-view {
+    width: 66.66%;
+}
+#sinoptico-details-container {
+    width: 33.33%;
+}


### PR DESCRIPTION
- Adds a new 'caratula-container' div to the Sinóptico view for displaying product and project information.
- Refactors the 'sinoptico-layout-container' to use a two-column flexbox layout.
- The main view (tree) now takes two-thirds of the width, and the details panel takes one-third.
- Adds corresponding CSS to 'style.css' to support the new layout.