### PR TITLE
Update firestore.rules with admin-only write access

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,21 +1,33 @@
 rules_version = '2';
+
 service cloud.firestore {
   match /databases/{database}/documents {
+
+    function isAdmin() {
+      return request.auth.uid in ['NIFudxxXnea8HqFzeMpxY0kma5b2', '7M6XuPSQf0UHUvet5KnEISxiYBT2'];
+    }
+
     // Reglas para colecciones existentes...
     
     // Regla para la nueva colección de Unidades de Medida
     match /unidadesDeMedida/{unidadId} {
-      allow read, write: if request.auth != null;
+      allow read: if request.auth != null;
+      allow write: if isAdmin();
+      allow create: if request.auth != null;
     }
 
     // Regla para la colección de Proveedores
     match /proveedores/{proveedorId} {
-      allow read, write: if request.auth != null;
+      allow read: if request.auth != null;
+      allow write: if isAdmin();
+      allow create: if request.auth != null;
     }
 
     // El resto de tus reglas
     match /{document=**} {
-      allow read, write: if request.auth != null;
+      allow read: if request.auth != null;
+      allow write: if isAdmin();
+      allow create: if request.auth != null;
     }
   }
 }


### PR DESCRIPTION
This commit updates the `firestore.rules` to introduce a more granular security model.

An `isAdmin()` function is added to identify administrators based on their UID.

The security rules are updated to:
- Grant full write access (create, update, delete) to administrators.
- Grant read and create access to all authenticated users.
- Restrict update and delete operations for non-admin users.