### PR TITLE
Fixes a TypeError where the 'collection' parameter in the `setInBatch…

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -280,8 +280,8 @@ async function seedDatabase() {
     const batch = writeBatch(db);
 
     // Helper para crear un nuevo documento en el batch
-    const setInBatch = (collection, data) => {
-        const docRef = doc(collection(db, collection), data.id);
+    const setInBatch = (collectionName, data) => {
+        const docRef = doc(collection(db, collectionName), data.id);
         batch.set(docRef, data);
     };
 


### PR DESCRIPTION
…` helper function was shadowing the imported `collection` function from Firestore. Renamed the parameter to `collectionName` to resolve the conflict, allowing the test data to be loaded correctly.