### PR TITLE
Refactor BOM views and navigation for clarity

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -130,15 +130,18 @@
                     <a href="#" data-view="dashboard" class="nav-link px-4 py-2 rounded-md text-sm font-medium text-slate-700 hover:bg-slate-100">
                         <i data-lucide="layout-dashboard" class="inline-block w-4 h-4 mr-1.5 -mt-0.5"></i>Dashboard
                     </a>
-                    <a href="#" data-view="sinoptico" class="nav-link px-4 py-2 rounded-md text-sm font-medium text-slate-700 hover:bg-slate-100">
-                        <i data-lucide="eye" class="inline-block w-4 h-4 mr-1.5 -mt-0.5"></i>Vista Sinóptica
-                    </a>
-                    <a href="#" data-view="sinoptico_tabular" class="nav-link px-4 py-2 rounded-md text-sm font-medium text-slate-700 hover:bg-slate-100">
-                        <i data-lucide="table" class="inline-block w-4 h-4 mr-1.5 -mt-0.5"></i>Sinóptico Tabular
-                    </a>
-                    <a href="#" data-view="flujograma" class="nav-link px-4 py-2 rounded-md text-sm font-medium text-slate-700 hover:bg-slate-100">
-                        <i data-lucide="git-branch-plus" class="inline-block w-4 h-4 mr-1.5 -mt-0.5"></i>Flujograma
-                    </a>
+
+                    <!-- Dropdown de Gestión BOM -->
+                    <div class="relative nav-dropdown">
+                        <button class="nav-link dropdown-toggle px-4 py-2 rounded-md text-sm font-medium text-slate-700 hover:bg-slate-100 flex items-center">
+                            <i data-lucide="git-merge" class="inline-block w-4 h-4 mr-1.5 -mt-0.5"></i>Gestión BOM
+                            <i data-lucide="chevron-down" class="w-4 h-4 ml-1"></i>
+                        </button>
+                        <div class="dropdown-menu absolute mt-2 w-56 bg-white border rounded-lg shadow-xl">
+                            <a href="#" data-view="arboles" class="nav-link flex items-center gap-3 px-4 py-3 text-sm hover:bg-slate-100"><i data-lucide="pencil-ruler" class="w-5 h-5 text-slate-500"></i>Editor de Árboles</a>
+                            <a href="#" data-view="sinoptico_tabular" class="nav-link flex items-center gap-3 px-4 py-3 text-sm hover:bg-slate-100"><i data-lucide="table" class="w-5 h-5 text-slate-500"></i>Reporte BOM (Tabular)</a>
+                        </div>
+                    </div>
 
                     <!-- Dropdown de Gestión -->
                     <div class="relative nav-dropdown">
@@ -147,7 +150,6 @@
                             <i data-lucide="chevron-down" class="w-4 h-4 ml-1"></i>
                         </button>
                         <div class="dropdown-menu absolute mt-2 w-56 bg-white border rounded-lg shadow-xl">
-                            <a href="#" data-view="arboles" class="nav-link flex items-center gap-3 px-4 py-3 text-sm hover:bg-slate-100"><i data-lucide="git-merge" class="w-5 h-5 text-slate-500"></i>Árboles de Producto</a>
                             <a href="#" data-view="productos" class="nav-link flex items-center gap-3 px-4 py-3 text-sm hover:bg-slate-100"><i data-lucide="package" class="w-5 h-5 text-slate-500"></i>Productos</a>
                             <a href="#" data-view="subproductos" class="nav-link flex items-center gap-3 px-4 py-3 text-sm hover:bg-slate-100"><i data-lucide="box" class="w-5 h-5 text-slate-500"></i>Subproductos</a>
                             <a href="#" data-view="insumos" class="nav-link flex items-center gap-3 px-4 py-3 text-sm hover:bg-slate-100"><i data-lucide="beaker" class="w-5 h-5 text-slate-500"></i>Insumos</a>

--- a/public/main.js
+++ b/public/main.js
@@ -44,10 +44,9 @@ const COLLECTIONS = {
 // --- Configuración de Vistas ---
 const viewConfig = {
     dashboard: { title: 'Dashboard', singular: 'Dashboard' },
-    sinoptico: { title: 'Vista Sinóptica', singular: 'Vista Sinóptica' },
-    sinoptico_tabular: { title: 'Sinóptico Tabular', singular: 'Sinóptico Tabular' },
+    sinoptico_tabular: { title: 'Reporte BOM (Tabular)', singular: 'Reporte BOM (Tabular)' },
     flujograma: { title: 'Flujograma de Procesos', singular: 'Flujograma' },
-    arboles: { title: 'Árboles de Producto', singular: 'Árbol' },
+    arboles: { title: 'Editor de Árboles', singular: 'Árbol' },
     profile: { title: 'Mi Perfil', singular: 'Mi Perfil' },
     productos: {
         title: 'Productos',
@@ -2271,7 +2270,7 @@ function initSinoptico() {
         const TEXT_COLOR_LIGHT = '#2d3748';
         const TITLE_COLOR = '#2563eb';
         const TYPE_COLORS = {
-            producto: '#3b82f6', subproducto: '#16a34a', insumo: '#f97316'
+            producto: '#3b82f6', subproducto: '#16a34a', insumo: '#64748b'
         };
         
         let cursorY = 0;

--- a/public/style.css
+++ b/public/style.css
@@ -136,7 +136,7 @@ body {
 
 .node-content[data-type="insumo"],
 .sinoptico-tree-item-content[data-type="insumo"] {
-    border-left: 4px solid #f59e0b !important; /* amber-500 */
+    border-left: 4px solid #9ca3af !important; /* gray-400 */
 }
 
 /* --- Estilos de Modales Mejorados --- */


### PR DESCRIPTION
This commit addresses the user's request to rethink the Bill of Materials (BOM) management interface to make it more useful and less repetitive.

Key changes:
- Removed the 'Vista Sinóptica' and 'Flujograma' views, which were identified as redundant or not yet implemented.
- Created a new 'Gestión BOM' dropdown in the main navigation to centralize BOM-related functionality.
- Renamed 'Árboles de Producto' to 'Editor de Árboles' and moved it into the 'Gestión BOM' menu.
- Renamed 'Sinóptico Tabular' to 'Reporte BOM (Tabular)' and moved it into the 'Gestión BOM' menu, designating it as the primary reporting tool.
- Updated view configuration titles in `main.js` to match the new navigation labels.
- Changed the color for 'Insumo' (supply) items from orange to a neutral gray in both the CSS for the tree view and the JavaScript for the PDF export, fulfilling the user's request for a more minimalist design.