### PR TITLE
fix: Correct query logic for personal tasks view

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -1282,7 +1282,7 @@ async function fetchAndRenderTasks() {
     try {
         if (taskState.activeFilter === 'personal') {
             const assignedQuery = query(tasksRef, where('assigneeUid', '==', user.uid));
-            const createdQuery = query(tasksRef, where('creatorUid', '==', user.uid), where('assigneeUid', '!=', user.uid));
+            const createdQuery = query(tasksRef, where('creatorUid', '==', user.uid));
 
             const [assignedSnap, createdSnap] = await Promise.all([getDocs(assignedQuery), getDocs(createdQuery)]);
 


### PR DESCRIPTION
This commit resolves a bug where tasks created by a user but not assigned to anyone would not appear in their "My Tasks" view.

The Firestore query for created tasks was overly restrictive. It has been simplified to correctly fetch all tasks created by the user, regardless of assignee. The client-side logic already handles de-duplication of tasks that are both created by and assigned to the same user.