### PR TITLE
debug: Temporarily disable Sortable.js

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -1422,7 +1422,7 @@ function renderTasks(tasks) {
             });
         }
 
-        initTasksSortable();
+        // initTasksSortable(); // Temporarily disabled for debugging
         lucide.createIcons();
     }, 0);
 }


### PR DESCRIPTION
This commit temporarily disables the drag-and-drop functionality in the tasks view by commenting out the call to `initTasksSortable()`.

This is a diagnostic step to test the hypothesis that the Sortable.js library is interfering with the DOM rendering of new task cards, causing them to not appear in the UI.

If this test is successful (i.e., tasks appear correctly), the next step will be to find a way to re-enable Sortable.js without causing this issue.