### PR TITLE
feat(tasks): Implement admin view toggle and timeline

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,6 +17,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@latest/Sortable.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/vis-timeline/8.3.0/vis-timeline-graph2d.min.js"></script>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/vis-timeline/8.3.0/vis-timeline-graph2d.min.css" rel="stylesheet" type="text/css" />
     <link rel="stylesheet" href="style.css">
 </head>
 <body class="bg-white">

--- a/public/style.css
+++ b/public/style.css
@@ -258,3 +258,42 @@ table.data-table .actions-cell button:hover {
 #sinoptico-tabular-container .text-slate-400 {
     font-style: italic;
 }
+
+/* --- Estilos para Vis.js Timeline --- */
+.vis-timeline {
+    border: 1px solid #e2e8f0;
+    border-radius: 0.5rem;
+    font-family: 'Inter', sans-serif;
+}
+.vis-item {
+    border-radius: 0.375rem;
+    box-shadow: 0 1px 3px 0 rgba(0,0,0,0.1), 0 1px 2px 0 rgba(0,0,0,0.06);
+    padding: 8px 12px;
+    font-size: 0.875rem;
+    font-weight: 500;
+}
+.vis-item.vis-selected {
+    border-color: #2563eb;
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.4);
+}
+
+/* Colores por prioridad */
+.vis-item.priority-high {
+    background-color: #fee2e2; /* red-100 */
+    border-color: #ef4444; /* red-500 */
+    color: #991b1b; /* red-800 */
+}
+.vis-item.priority-medium {
+    background-color: #fef3c7; /* yellow-100 */
+    border-color: #f59e0b; /* amber-500 */
+    color: #92400e; /* amber-800 */
+}
+.vis-item.priority-low {
+    background-color: #f1f5f9; /* slate-100 */
+    border-color: #64748b; /* slate-500 */
+    color: #334155; /* slate-700 */
+}
+.vis-current-time {
+    background-color: #ef4444; /* red-500 */
+    width: 2px;
+}


### PR DESCRIPTION
This commit introduces a new workflow for the Tasks view and enhances the admin dashboard.

Key changes:
- All users, including admins, now land on the Kanban board view first.
- For admins, a new "Admin View" button is added to the Kanban board, allowing them to switch to the admin dashboard.
- The admin dashboard now features a "Back to Board" button to return to the Kanban view.
- A new interactive timeline, powered by vis.js, has been added to the admin dashboard. This timeline displays tasks with due dates, includes a "today" marker, and is color-coded by task priority.
- Tasks on the timeline are clickable, opening the task detail modal for quick editing and review.