### PR TITLE
Fix: Reemplaza el servicio de avatares roto por uno funcional

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -26,12 +26,12 @@ const db = getFirestore(app);
 // =================================================================================
 const LOCK_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutos en milisegundos
 const PREDEFINED_AVATARS = [
-    'https://source.boringavatars.com/marble/120/Maria%20Mitchell?colors=264653,2a9d8f,e9c46a,f4a261,e76f51',
-    'https://source.boringavatars.com/beam/120/Mary%20Jackson?colors=264653,2a9d8f,e9c46a,f4a261,e76f51',
-    'https://source.boringavatars.com/pixel/120/Grace%20Hopper?colors=264653,2a9d8f,e9c46a,f4a261,e76f51',
-    'https://source.boringavatars.com/sunset/120/Hedy%20Lamarr?colors=264653,2a9d8f,e9c46a,f4a261,e76f51',
-    'https://source.boringavatars.com/ring/120/Ada%20Lovelace?colors=264653,2a9d8f,e9c46a,f4a261,e76f51',
-    'https://source.boringavatars.com/bauhaus/120/Katherine%20Johnson?colors=264653,2a9d8f,e9c46a,f4a261,e76f51'
+    'https://ui-avatars.com/api/?name=Maria%20Mitchell&background=random&size=120',
+    'https://ui-avatars.com/api/?name=Mary%20Jackson&background=random&size=120',
+    'https://ui-avatars.com/api/?name=Grace%20Hopper&background=random&size=120',
+    'https://ui-avatars.com/api/?name=Hedy%20Lamarr&background=random&size=120',
+    'https://ui-avatars.com/api/?name=Ada%20Lovelace&background=random&size=120',
+    'https://ui-avatars.com/api/?name=Katherine%20Johnson&background=random&size=120'
 ];
 const COLLECTIONS = {
     PRODUCTOS: 'productos',


### PR DESCRIPTION
El servicio `source.boringavatars.com` utilizado para los avatares predefinidos ha caducado su certificado SSL, lo que resulta en errores `net::ERR_CERT_DATE_INVALID` y la no visualización de las imágenes.

Este commit reemplaza las URLs de `boringavatars` con las de `ui-avatars.com`, un servicio que ya está en uso en la aplicación para generar avatares de respaldo. Se mantienen los nombres de las personas en las URLs para generar avatares consistentes con los anteriores, aunque con un estilo visual diferente.

Esto resuelve el error y permite que los avatares se carguen correctamente en el modal de selección.