### PR TITLE
Fix: Remove duplicate 'users' variable declaration

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -1888,9 +1888,6 @@ function setupAdminTaskViewListeners() {
         });
     }
 
-    const users = appState.collections.usuarios || [];
-    controls.user.innerHTML = '<option value="all">Todos los usuarios</option>' + users.map(u => `<option value="${u.docId}">${u.name || u.email}</option>`).join('');
-
     document.addEventListener('click', (e) => {
         if (controls.timelineFilterBtn && !controls.timelineFilterBtn.contains(e.target) && !controls.timelineFilterDropdown.contains(e.target)) {
             controls.timelineFilterDropdown.classList.add('hidden');


### PR DESCRIPTION
Removes a redundant declaration of the `users` constant inside the `setupAdminTaskViewListeners` function in `public/main.js`.

This duplicate declaration was causing a critical `Uncaught SyntaxError: Identifier 'users' has already been declared`, which prevented the application's JavaScript from running correctly.

The removed code block was a duplicate of logic that already existed earlier in the function for populating user dropdowns.