### PR TITLE
feat: Replace timeline with calendar view for tasks

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,8 +17,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@latest/Sortable.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script src="https://unpkg.com/vis-timeline@latest/standalone/umd/vis-timeline-graph2d.min.js"></script>
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/vis-timeline/8.3.0/vis-timeline-graph2d.min.css" rel="stylesheet" type="text/css" />
     <link rel="stylesheet" href="style.css">
 </head>
 <body class="bg-white">


### PR DESCRIPTION
Replace the existing vis.js-based timeline with a new, custom-built calendar view in the admin task dashboard.

This new implementation provides:
- A monthly view showing Monday to Friday with week numbers.
- A weekly view showing Monday to Friday with the week number.
- Navigation to move between months/weeks and jump to the current day.
- Display of tasks on the calendar based on their due date.
- Filtering of tasks by priority.
- The ability to create a new task by clicking on a day.

The `vis-timeline` library and all its associated code have been removed.