### PR TITLE
fix: Correctly assign classes to prevent calendar crash

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -2169,8 +2169,7 @@ function displayTasksOnCalendar(tasks) {
                 const priority = task.priority || 'medium';
 
                 const taskElement = document.createElement('div');
-                taskElement.className = `p-1.5 rounded-md text-xs font-semibold cursor-pointer hover:opacity-80 truncate`;
-                taskElement.classList.add(priorityClasses[priority]);
+                taskElement.className = `p-1.5 rounded-md text-xs font-semibold cursor-pointer hover:opacity-80 truncate ${priorityClasses[priority]}`;
                 taskElement.textContent = task.title;
                 taskElement.title = task.title;
                 taskElement.dataset.taskId = task.docId;


### PR DESCRIPTION
This commit fixes a bug that caused the application to crash when rendering tasks on the new calendar view.

The error was an `InvalidCharacterError` caused by attempting to add a string with multiple space-separated CSS classes to a DOM element's `classList`.

The fix replaces the incorrect `classList.add()` call with a direct assignment to `element.className`, concatenating all necessary classes into a single string.

This resolves two issues:
1. Tasks not appearing on the calendar.
2. The admin task table failing to render due to the script crash.