### PR TITLE
refactor(tasks): Set Kanban as Default and Create Role-Aware Dashboard

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -395,3 +395,12 @@ table.data-table .actions-cell button:hover {
     transform: translateY(-50%);
     font-size: 14px;
 }
+
+/* --- Kanban Column Collapsing --- */
+.task-column.collapsed .task-list {
+    display: none;
+}
+
+.task-column.collapsed .kanban-toggle-btn .lucide {
+    transform: rotate(-90deg);
+}


### PR DESCRIPTION
This commit refactors the Task Manager based on user feedback to make the Kanban board the primary view and the dashboard a secondary, role-aware analytics tool.

- The `runTasksLogic` function now defaults to showing the Kanban board for all users.
- A "Ver Estadísticas" button has been added to the Kanban view to navigate to the dashboard.
- The previous `runAdminDashboard` function has been refactored into a new `renderTaskDashboardView` which serves a simplified, personal dashboard to regular users and the full-featured dashboard to admins.
- As an improvement, Kanban columns are now collapsible to allow users to customize their view.