### PR TITLE
Fix: Correct state handling for sinoptico editing

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -3479,8 +3479,20 @@ function renderCaratula(producto, cliente) {
 }
 
 function openSinopticoEditModal(nodeId) {
-    const product = appState.collections[COLLECTIONS.PRODUCTOS].find(p => p.docId === appState.sinopticoState.activeTreeDocId);
-    if (!product) return;
+    const activeProductDocId = appState.currentView === 'sinoptico_tabular'
+        ? appState.sinopticoTabularState?.selectedProduct?.docId
+        : appState.sinopticoState?.activeTreeDocId;
+
+    if (!activeProductDocId) {
+        showToast('Error: No hay un producto activo seleccionado.', 'error');
+        return;
+    }
+
+    const product = appState.collections[COLLECTIONS.PRODUCTOS].find(p => p.docId === activeProductDocId);
+    if (!product) {
+        showToast('Error: Producto no encontrado en la colección.', 'error');
+        return;
+    }
     const node = findNode(nodeId, product.estructura);
     if (!node) return;
 
@@ -3536,7 +3548,16 @@ async function handleSinopticoFormSubmit(e) {
         return;
     }
 
-    const product = appState.collections[COLLECTIONS.PRODUCTOS].find(p => p.docId === appState.sinopticoState.activeTreeDocId);
+    const activeProductDocId = appState.currentView === 'sinoptico_tabular'
+        ? appState.sinopticoTabularState?.selectedProduct?.docId
+        : appState.sinopticoState?.activeTreeDocId;
+
+    if (!activeProductDocId) {
+        showToast('Error: No se pudo encontrar el producto activo.', 'error');
+        return;
+    }
+    const product = appState.collections[COLLECTIONS.PRODUCTOS].find(p => p.docId === activeProductDocId);
+
     if (!product) {
         showToast('Error: No se pudo encontrar el producto activo.', 'error');
         return;
@@ -3559,8 +3580,12 @@ async function handleSinopticoFormSubmit(e) {
 
             document.getElementById(form.closest('.fixed').id).remove();
 
-            renderTree();
-            renderDetailView(nodeId);
+            if (appState.currentView === 'sinoptico_tabular') {
+                runSinopticoTabularLogic();
+            } else {
+                renderTree();
+                renderDetailView(nodeId);
+            }
         } catch (error) {
             console.error("Error saving sinoptico node:", error);
             showToast('Error al guardar los cambios.', 'error');


### PR DESCRIPTION
The `openSinopticoEditModal` and `handleSinopticoFormSubmit` functions were incorrectly relying on `appState.sinopticoState` even when the edit was initiated from the `sinoptico_tabular` view. This caused a TypeError because `appState.sinopticoState` is null when the tabular view is active.

This patch fixes the issue by:
1.  Checking the `appState.currentView` to determine the active view.
2.  Retrieving the active product's document ID from the correct state object (`appState.sinopticoTabularState` or `appState.sinopticoState`).
3.  Adding error handling to show a message if no product is active.
4.  Ensuring that after an edit, the correct view (`tabular` or `graphical`) is re-rendered.