### PR TITLE
Fix BOM table update bug and clean up navigation menu.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -144,7 +144,6 @@
                         </button>
                         <div class="dropdown-menu absolute mt-2 w-60 bg-white border rounded-lg shadow-xl">
                             <a href="#" data-view="arboles" class="nav-link flex items-center gap-3 px-4 py-3 text-sm hover:bg-slate-100"><i data-lucide="pencil-ruler" class="w-5 h-5 text-slate-500"></i>Editor de Árboles BOM</a>
-                            <a href="#" data-view="sinoptico_tabular" class="nav-link flex items-center gap-3 px-4 py-3 text-sm hover:bg-slate-100"><i data-lucide="table" class="w-5 h-5 text-slate-500"></i>Reporte BOM (Tabular)</a>
                             <div class="border-t my-1"></div>
                             <a href="#" data-view="productos" class="nav-link flex items-center gap-3 px-4 py-3 text-sm hover:bg-slate-100"><i data-lucide="package" class="w-5 h-5 text-slate-500"></i>Productos</a>
                             <a href="#" data-view="proyectos" class="nav-link flex items-center gap-3 px-4 py-3 text-sm hover:bg-slate-100"><i data-lucide="kanban-square" class="w-5 h-5 text-slate-500"></i>Proyectos</a>

--- a/public/main.js
+++ b/public/main.js
@@ -54,7 +54,6 @@ const COLLECTIONS = {
 // --- Configuración de Vistas ---
 const viewConfig = {
     dashboard: { title: 'Dashboard', singular: 'Dashboard' },
-    sinoptico_tabular: { title: 'Reporte BOM (Tabular)', singular: 'Reporte BOM (Tabular)' },
     flujograma: { title: 'Flujograma de Procesos', singular: 'Flujograma' },
     arboles: { title: 'Editor de Árboles', singular: 'Árbol' },
     profile: { title: 'Mi Perfil', singular: 'Mi Perfil' },
@@ -3577,6 +3576,12 @@ async function handleSinopticoFormSubmit(e) {
             document.getElementById(form.closest('.fixed').id).remove();
 
             if (appState.currentView === 'sinoptico_tabular') {
+                // BUG FIX: Explicitly update the state object before re-rendering.
+                // This ensures the view uses the most recent data immediately,
+                // without waiting for the Firestore listener to refresh the collection.
+                if(appState.sinopticoTabularState.selectedProduct && appState.sinopticoTabularState.selectedProduct.docId === product.docId) {
+                    appState.sinopticoTabularState.selectedProduct.estructura = product.estructura;
+                }
                 runSinopticoTabularLogic();
             } else {
                 renderTree();


### PR DESCRIPTION
This commit addresses two issues based on user feedback:

1.  A bug in the tabular BOM report where modifying the "Cantidad por pieza" of a component would not immediately update the value in the table. The fix ensures the local application state is updated correctly after the database write, forcing a re-render with the new data.

2.  The "Reporte BOM (Tabular)" link has been removed from the "Gestión" dropdown menu to simplify the user interface, as requested. The corresponding view configuration has also been removed from the code.