### PR TITLE
Fix: Ensure droppable area is always present for parent nodes

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -3373,7 +3373,7 @@ function renderNodo(nodo) {
                     </div>
                 </div>
                 ${commentText}
-                ${(nodo.children && nodo.children.length > 0) ? `<ul class="node-children-list">${nodo.children.map(renderNodo).join('')}</ul>` : ''}
+                ${addableChildren[nodo.tipo].length > 0 ? `<ul class="node-children-list">${(nodo.children || []).map(renderNodo).join('')}</ul>` : ''}
             </li>`;
 }
 


### PR DESCRIPTION
This commit fixes a bug where it was impossible to drag-and-drop a component into a subproduct that had no children.

The `renderNodo` function only rendered a `<ul>` element for children if the `children` array was not empty. This meant that when the last child was dragged out of a subproduct, the `<ul>` element was removed from the DOM, and with it, the drop target for Sortable.js.

The fix modifies `renderNodo` to always render a `<ul>` for node types that can accept children ('producto' and 'subproducto'), even if the `children` array is empty. This ensures there is always a valid drop zone, making the drag-and-drop behavior more consistent and intuitive.