### PR TITLE
feat: Add comprehensive columns to Sinoptico table and forms

### DIFF
--- a/jules-scratch/verification/verify_sinoptico.py
+++ b/jules-scratch/verification/verify_sinoptico.py
@@ -1,0 +1,62 @@
+import asyncio
+from playwright.async_api import async_playwright, expect
+import os
+
+async def main():
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=True)
+        page = await browser.new_page()
+
+        base_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        index_path = os.path.join(base_dir, 'public', 'index.html')
+
+        await page.goto(f"file://{index_path}")
+
+        await page.evaluate("""
+            document.getElementById('loading-overlay').style.display = 'none';
+            document.getElementById('auth-container').style.display = 'none';
+            document.getElementById('app-view').style.display = 'flex';
+        """)
+        print("Bypassed login wall by showing main app view.")
+
+        # Force the dropdown to open using standard JavaScript
+        await page.evaluate("""
+            const buttons = document.querySelectorAll("button.dropdown-toggle");
+            const gestionButton = Array.from(buttons).find(btn => btn.textContent.includes('Gestión'));
+            if (gestionButton) {
+                const dropdown = gestionButton.closest('.nav-dropdown');
+                dropdown.classList.add('open');
+            }
+        """)
+        print("Forced 'Gestión' dropdown to open.")
+
+        # Now click the 'Productos' link, which should be visible
+        await page.locator("a[data-view='productos']").click()
+        await expect(page.locator("h2:has-text('Productos')")).to_be_visible()
+
+        # Click the "Add" button to open the form modal
+        await page.locator("#add-new-button").click()
+
+        # Verify the form is open and take a screenshot
+        await expect(page.locator("h3:has-text('Agregar Producto')")).to_be_visible()
+        await expect(page.locator("label:has-text('Imagen (URL)')")).to_be_visible()
+        await expect(page.locator("label:has-text('Aspecto')")).to_be_visible()
+        await expect(page.locator("label:has-text('Proceso')")).to_be_visible()
+        await page.screenshot(path="jules-scratch/verification/edit-form.png")
+        print("Screenshot of 'Add Product' form taken.")
+
+        # Test validation
+        await page.locator("textarea[name='descripcion']").fill("")
+        await page.locator("input[name='codigo']").fill("")
+        await page.locator("button[type='submit']:has-text('Guardar')").click()
+
+        # Verify validation error
+        await expect(page.locator("h3:has-text('Agregar Producto')")).to_be_visible() # Modal should still be open
+        await expect(page.locator("p.text-red-600:has-text('Este campo es obligatorio.')")).to_have_count(2)
+        await page.screenshot(path="jules-scratch/verification/validation-error.png")
+        print("Screenshot of validation error taken.")
+
+        await browser.close()
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/public/main.js
+++ b/public/main.js
@@ -93,17 +93,23 @@ const viewConfig = {
             { key: 'codigo_cliente', label: 'Cód. Cliente' }
         ],
         fields: [
-            { key: 'codigo', label: 'Código Interno', type: 'text', required: true },
+            { key: 'descripcion', label: 'Versión del vehículo', type: 'textarea', required: true },
+            { key: 'codigo', label: 'Número de pieza', type: 'text', required: true },
+            { key: 'imagen', label: 'Imagen (URL)', type: 'text' },
+            { key: 'piezas_por_vehiculo', label: 'Piezas/Vehículo [unid.]', type: 'number' },
+            { key: 'proceso', label: 'Proceso', type: 'search-select', searchKey: COLLECTIONS.PROCESOS },
+            { key: 'lc', label: 'LC', type: 'text' },
+            { key: 'site_kd', label: 'Planta / KD', type: 'text' },
+            { key: 'aspecto', label: 'Aspecto', type: 'select', options: ['Sí', 'No'] },
+            { key: 'material', label: 'Material', type: 'text' },
+            { key: 'color', label: 'Color', type: 'text' },
+            { key: 'materia_prima', label: 'Materia prima', type: 'text' },
+            { key: 'proveedorId', label: 'Proveedor de materia prima', type: 'search-select', searchKey: COLLECTIONS.PROVEEDORES },
+            { key: 'cantidad_por_pieza', label: 'Cantidad por pieza', type: 'number' },
+            { key: 'comentarios', label: 'Comentarios', type: 'textarea' },
+            { key: 'version', label: 'Versión Técnica', type: 'text' },
             { key: 'codigo_cliente', label: 'Código de Cliente', type: 'text' },
-            { key: 'descripcion', label: 'Descripción', type: 'textarea', required: true },
-            { key: 'version', label: 'Versión', type: 'text' },
-            {
-                key: 'proyectoId',
-                label: 'Proyecto Asociado',
-                type: 'search-select',
-                searchKey: COLLECTIONS.PROYECTOS,
-                required: false
-            },
+            { key: 'proyectoId', label: 'Proyecto Asociado', type: 'search-select', searchKey: COLLECTIONS.PROYECTOS, required: false },
         ]
     },
     subproductos: {
@@ -116,12 +122,23 @@ const viewConfig = {
             { key: 'peso', label: 'Peso' }
         ],
         fields: [
-            { key: 'codigo', label: 'Código', type: 'text', required: true },
             { key: 'nombre', label: 'Nombre', type: 'text', required: true },
-            { key: 'descripcion', label: 'Descripción', type: 'textarea' },
+            { key: 'codigo', label: 'Número de pieza', type: 'text', required: true },
+            { key: 'imagen', label: 'Imagen (URL)', type: 'text' },
+            { key: 'piezas_por_vehiculo', label: 'Piezas/Vehículo [unid.]', type: 'number' },
+            { key: 'proceso', label: 'Proceso', type: 'search-select', searchKey: COLLECTIONS.PROCESOS },
+            { key: 'lc', label: 'LC', type: 'text' },
+            { key: 'site_kd', label: 'Planta / KD', type: 'text' },
+            { key: 'aspecto', label: 'Aspecto', type: 'select', options: ['Sí', 'No'] },
+            { key: 'material', label: 'Material', type: 'text' },
+            { key: 'color', label: 'Color', type: 'text' },
+            { key: 'materia_prima', label: 'Materia prima', type: 'text' },
+            { key: 'proveedorId', label: 'Proveedor de materia prima', type: 'search-select', searchKey: COLLECTIONS.PROVEEDORES },
+            { key: 'cantidad_por_pieza', label: 'Cantidad por pieza', type: 'number' },
+            { key: 'comentarios', label: 'Comentarios', type: 'textarea' },
+            { key: 'descripcion', label: 'Descripción Adicional', type: 'textarea' },
             { key: 'peso', label: 'Peso (ej: 150kg)', type: 'text' },
             { key: 'medidas', label: 'Medidas (ej: 10x20x5 cm)', type: 'text' },
-            { key: 'observaciones', label: 'Observaciones', type: 'textarea' },
         ]
     },
     insumos: {
@@ -134,14 +151,21 @@ const viewConfig = {
             { key: 'material', label: 'Material' }
         ],
         fields: [
-            { key: 'codigo', label: 'Código', type: 'text', required: true },
             { key: 'descripcion', label: 'Descripción', type: 'textarea', required: true },
-            { key: 'unidad_medida', label: 'Unidad de Medida', type: 'select', options: ['m', 'ml', 'm2', 'm3', 'kg', 'g', 'l', 'un', 'cj', 'pq'], required: true },
+            { key: 'codigo', label: 'Número de pieza', type: 'text', required: true },
+            { key: 'imagen', label: 'Imagen (URL)', type: 'text' },
+            { key: 'piezas_por_vehiculo', label: 'Piezas/Vehículo [unid.]', type: 'number' },
+            { key: 'proceso', label: 'Proceso', type: 'search-select', searchKey: COLLECTIONS.PROCESOS },
+            { key: 'lc', label: 'LC', type: 'text' },
+            { key: 'site_kd', label: 'Planta / KD', type: 'text' },
+            { key: 'aspecto', label: 'Aspecto', type: 'select', options: ['Sí', 'No'] },
             { key: 'material', label: 'Material', type: 'text' },
-            { key: 'codigo_proveedor', label: 'Código Proveedor', type: 'text' },
-            { key: 'piezas_por_vehiculo', label: 'Piezas por Vehículo', type: 'number' },
-            { key: 'proceso', label: 'Proceso', type: 'text' },
             { key: 'color', label: 'Color', type: 'text' },
+            { key: 'materia_prima', label: 'Materia prima', type: 'text' },
+            { key: 'proveedorId', label: 'Proveedor de materia prima', type: 'search-select', searchKey: COLLECTIONS.PROVEEDORES },
+            { key: 'cantidad_por_pieza', label: 'Cantidad por pieza', type: 'number' },
+            { key: 'unidadId', label: 'Unidad', type: 'search-select', searchKey: COLLECTIONS.UNIDADES, required: true },
+            { key: 'comentarios', label: 'Comentarios', type: 'textarea' },
         ]
     },
     clientes: { title: 'Clientes', singular: 'Cliente', dataKey: COLLECTIONS.CLIENTES, columns: [ { key: 'id', label: 'Código' }, { key: 'descripcion', label: 'Descripción' } ], fields: [ { key: 'id', label: 'Código', type: 'text', required: true }, { key: 'descripcion', label: 'Descripción', type: 'text', required: true } ] },
@@ -3897,11 +3921,24 @@ function runSinopticoTabularLogic() {
 
     const renderTabularTable = (data) => {
         const columns = [
-            { key: 'descripcion', label: 'Descripción' }, { key: 'nivel', label: 'Nivel' },
-            { key: 'codigo', label: 'Código' }, { key: 'tipo', label: 'Tipo' },
-            { key: 'cantidad', label: 'Cantidad por pieza' }, { key: 'unidad', label: 'Unidad' },
-            { key: 'proveedor', label: 'Proveedor' }, { key: 'material', label: 'Material' },
-            { key: 'observaciones', label: 'Comentarios' }, { key: 'acciones', label: 'Acciones' }
+            { key: 'descripcion', label: 'Descripción' },
+            { key: 'nivel', label: 'Nivel' },
+            { key: 'version', label: 'Versión del vehículo' },
+            { key: 'codigo', label: 'Número de pieza' },
+            { key: 'imagen', label: 'Imagen' },
+            { key: 'piezas_vh', label: 'Piezas/Vehículo [unid.]' },
+            { key: 'proceso', label: 'Proceso' },
+            { key: 'lc', label: 'LC' },
+            { key: 'site_kd', label: 'Planta / KD' },
+            { key: 'aspecto', label: 'Aspecto' },
+            { key: 'material', label: 'Material' },
+            { key: 'color', label: 'Color' },
+            { key: 'materia_prima', label: 'Materia prima' },
+            { key: 'proveedor', label: 'Proveedor de materia prima' },
+            { key: 'cantidad', label: 'Cantidad por pieza' },
+            { key: 'unidad', label: 'Unidad' },
+            { key: 'observaciones', label: 'Comentarios' },
+            { key: 'acciones', label: 'Acciones' }
         ];
 
         if (data.length === 0) return `<p class="text-slate-500 p-4 text-center">El producto seleccionado no tiene una estructura definida.</p>`;
@@ -3918,17 +3955,37 @@ function runSinopticoTabularLogic() {
             let prefix = lineage.map(parentIsNotLast => parentIsNotLast ? '│&nbsp;&nbsp;&nbsp;&nbsp;' : '&nbsp;&nbsp;&nbsp;&nbsp;').join('');
             if (level > 0)  prefix += isLast ? '└─ ' : '├─ ';
 
-            const cantidad = node.quantity ?? NA;
-            let unidad = NA, proveedor = NA, material = NA;
+            const vehicleVersion = item.version || (node.tipo === 'producto' ? item.descripcion : NA);
+            const partNumber = item.id || NA;
+            const imagen = item.imagen ? `<a href="${item.imagen}" target="_blank" class="text-blue-500 hover:underline">Ver Imagen</a>` : NA;
+            const piezasVh = item.piezas_por_vehiculo || NA;
+            let proceso = item.proceso || NA;
+            if (item.proceso && appState.collectionsById[COLLECTIONS.PROCESOS]) {
+                const procesoData = appState.collectionsById[COLLECTIONS.PROCESOS].get(item.proceso);
+                proceso = procesoData ? procesoData.descripcion : item.proceso;
+            }
+            const lc = item.lc || NA;
+            const siteKd = item.site_kd || NA;
+            const aspecto = item.aspecto || NA;
+            const material = item.material || NA;
+            const color = item.color || NA;
+            const materiaPrima = item.materia_prima || NA;
 
-            if (node.tipo === 'insumo') {
-                const unidadData = item.unidadMedidaId ? appState.collectionsById[COLLECTIONS.UNIDADES].get(item.unidadMedidaId) : null;
-                unidad = unidadData ? unidadData.id : '';
-                const proveedorData = item.proveedorId ? appState.collectionsById[COLLECTIONS.PROVEEDORES].get(item.proveedorId) : null;
-                proveedor = proveedorData ? proveedorData.descripcion : '';
-                material = item.material || '';
+            let proveedor = NA;
+            if (item.proveedorId) {
+                const supplier = appState.collectionsById[COLLECTIONS.PROVEEDORES].get(item.proveedorId);
+                proveedor = supplier ? supplier.descripcion : (item.proveedorId || NA);
             }
 
+            const cantidad = node.quantity ?? NA;
+
+            let unidad = NA;
+            if (item.unidadId) {
+                const unitData = appState.collectionsById[COLLECTIONS.UNIDADES]?.get(item.unidadId);
+                unidad = unitData ? unitData.id : item.unidadId;
+            }
+
+            const comentarios = node.comment || '';
             const actionsHTML = (node.tipo !== 'producto' || level === 0)
                 ? `<button data-action="edit-tabular-node" data-node-id="${node.id}" class="p-1 text-blue-600 hover:bg-blue-100 rounded-md" title="Editar Cantidad/Comentario"><i data-lucide="pencil" class="w-4 h-4 pointer-events-none"></i></button>`
                 : '';
@@ -3936,13 +3993,21 @@ function runSinopticoTabularLogic() {
             tableHTML += `<tr class="bg-white border-b hover:bg-gray-100" data-node-id="${node.id}">
                 <td class="px-4 py-2 font-mono font-medium text-gray-900 whitespace-nowrap"><span class="font-sans">${prefix}</span>${item.descripcion || item.nombre}</td>
                 <td class="px-4 py-2 text-center">${node.originalLevel ?? level}</td>
-                <td class="px-4 py-2">${item.id}</td>
-                <td class="px-4 py-2"><span class="px-2 py-1 text-xs font-medium rounded-full bg-slate-100 text-slate-700">${node.tipo}</span></td>
+                <td class="px-4 py-2">${vehicleVersion}</td>
+                <td class="px-4 py-2">${partNumber}</td>
+                <td class="px-4 py-2">${imagen}</td>
+                <td class="px-4 py-2">${piezasVh}</td>
+                <td class="px-4 py-2">${proceso}</td>
+                <td class="px-4 py-2">${lc}</td>
+                <td class="px-4 py-2">${siteKd}</td>
+                <td class="px-4 py-2">${aspecto}</td>
+                <td class="px-4 py-2">${material}</td>
+                <td class="px-4 py-2">${color}</td>
+                <td class="px-4 py-2">${materiaPrima}</td>
+                <td class="px-4 py-2">${proveedor}</td>
                 <td class="px-4 py-2 text-right">${cantidad}</td>
                 <td class="px-4 py-2 text-center">${unidad}</td>
-                <td class="px-4 py-2">${proveedor}</td>
-                <td class="px-4 py-2">${material}</td>
-                <td class="px-4 py-2">${node.comment || ''}</td>
+                <td class="px-4 py-2">${comentarios}</td>
                 <td class="px-4 py-2 text-center">${actionsHTML}</td>
             </tr>`;
         });


### PR DESCRIPTION
This change significantly expands the data displayed in the 'Reporte BOM (Tabular)' (Sinoptico) view and the corresponding data entry forms for products, sub-products, and inputs.

- Adds all 15 requested columns to the Sinoptico table, including fields for vehicle version, image, pieces per vehicle, process, LC, KD, aspect, material, color, raw material, supplier, quantity, and comments.
- Updates the data entry forms for Products, Sub-products, and Insums to include all corresponding new fields, allowing users to capture this detailed information.
- Converts text fields for linked data (like 'Proceso') into 'search-select' dropdowns to allow linking to master data, improving data consistency.
- Implements lookup logic in the Sinoptico table rendering to display user-friendly descriptions for linked data (e.g., showing a process name instead of an ID).
- Ensures the validation system correctly handles the newly required fields ('Número de pieza' and 'Versión del vehículo') to prevent saving incomplete records.