### PR TITLE
fix(auth): Force user reload to fix verification screen lock

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -3095,6 +3095,9 @@ function populateTaskAssigneeDropdown() {
 
 onAuthStateChanged(auth, async (user) => {
     if (user) {
+        // Forzar la recarga del estado del usuario para obtener el estado de emailVerified más reciente.
+        await user.reload();
+
         if (user.emailVerified) {
             const wasAlreadyLoggedIn = !!appState.currentUser;
 


### PR DESCRIPTION
After a user verifies their email, the app was not correctly recognizing the updated `emailVerified` status, causing the user to be stuck on the verification page even after refreshing.

This change adds `await user.reload()` at the start of the `onAuthStateChanged` listener. This forces the Firebase SDK to fetch the latest user data from the server, ensuring the `emailVerified` property is up-to-date and allowing the user to proceed into the application after successful verification.