### PR TITLE
fix(auth): Resolve registration flow and email verification issues

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -7,6 +7,22 @@ service cloud.firestore {
       return request.auth.uid in ['NIFudxxXnea8HqFzeMpxY0kma5b2', '7M6XuPSQf0UHUvet5KnEISxiYBT2'];
     }
 
+    // --- USUARIOS ---
+    match /usuarios/{userId} {
+      // Un usuario puede leer su propio perfil. Los admins pueden leer todos.
+      allow read: if request.auth.uid == userId || isAdmin();
+
+      // Un usuario puede crear su propio documento de perfil durante el registro.
+      allow create: if request.auth.uid == userId;
+
+      // Un usuario puede actualizar su propio perfil (nombre, avatar, etc.).
+      // Los administradores pueden actualizar cualquier perfil (para cambiar roles, etc.).
+      allow update: if request.auth.uid == userId || isAdmin();
+
+      // Solo los administradores pueden eliminar usuarios.
+      allow delete: if isAdmin();
+    }
+
     // Reglas para colecciones existentes...
     
     // Regla para la nueva colección de Unidades de Medida


### PR DESCRIPTION
This commit addresses a series of issues in the user registration and email verification flow.

The primary issue was a "Missing or insufficient permissions" error that occurred when a new user tried to register. This was caused by Firestore security rules that did not permit a non-admin user to create their own document in the `usuarios` collection. This commit introduces a new, more specific rule in `firestore.rules` that explicitly allows users to create and update their own user document, resolving the permissions error.

Additionally, this commit includes two client-side improvements in `public/main.js`:
1.  Adds robust `try...catch` error handling around the `sendEmailVerification` call to provide better user feedback and logging if the email sending process fails.
2.  Adds `await user.reload()` to the `onAuthStateChanged` listener to force a refresh of the user's authentication state. This fixes a follow-up issue where users would get stuck on the verification page because their `emailVerified` status was not being updated on the client after they verified their email in another tab.