### PR TITLE
Fix: Improve PDF export for all sinoptico views

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -427,6 +427,23 @@ async function saveDocument(collectionName, data, docId = null) {
     }
 }
 
+async function getLogoBase64() {
+    try {
+        const response = await fetch('logo.png');
+        if (!response.ok) return null;
+        const blob = await response.blob();
+        return new Promise((resolve, reject) => {
+            const reader = new FileReader();
+            reader.onloadend = () => resolve(reader.result);
+            reader.onerror = reject;
+            reader.readAsDataURL(blob);
+        });
+    } catch (error) {
+        console.error("Could not fetch logo.png:", error);
+        return null;
+    }
+}
+
 async function deleteDocument(collectionName, docId) {
     try {
         await deleteDoc(doc(db, collectionName, docId));


### PR DESCRIPTION
This commit addresses several issues with the PDF export for both the graphical and tabular sinoptico views and fixes a subsequent ReferenceError.

Changes:
- The company logo was missing from the header in both exports.
- The layout was compacted, with text overlapping, especially for long descriptions in the graphical view.
- The hierarchy of components was jumbled and difficult to read in the graphical view.
- A `ReferenceError: getLogoBase64 is not defined` was occurring in the tabular export.

The `exportProductTreePdf` (graphical) function has been refactored to:
- Add the company logo to the PDF header by fetching the `logo.png` image.
- Implement dynamic row height calculation based on the content of each component's description. This prevents text from overlapping and ensures the layout is correctly spaced.
- Improve the drawing of hierarchy lines to be consistent with the dynamic row height, making the structure clear and easy to follow.

The `exportSinopticoTabularToPdf` (tabular) function has been updated to:
- Correctly include the company logo in the header.

A new helper function `getLogoBase64` has been added to facilitate loading the logo image for both export functions, resolving the ReferenceError.