### PR TITLE
fix: Prioritize width in PDF table scaling

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -4483,16 +4483,12 @@ async function exportSinopticoTabularToPdf() {
 
         const imgAspectRatio = imgProps.width / imgProps.height;
 
-        let finalImgWidth = availableWidth;
-        let finalImgHeight = finalImgWidth / imgAspectRatio;
+        const finalImgWidth = availableWidth;
+        const finalImgHeight = finalImgWidth / imgAspectRatio;
 
-        // If the scaled height is still too tall, scale again based on height
-        if (finalImgHeight > availableHeight) {
-            finalImgHeight = availableHeight;
-            finalImgWidth = finalImgHeight * imgAspectRatio;
-        }
-
-        // We don't need to add a new page, as we are scaling to fit.
+        // Add the image, scaled to the full width of the page.
+        // The height will adjust proportionally. This might make the content very small
+        // if the table is long, but it will always use the full width as requested.
         doc.addImage(imgData, 'PNG', PAGE_MARGIN, cursorY, finalImgWidth, finalImgHeight);
 
         // --- 4. Save PDF ---


### PR DESCRIPTION
This commit refactors the scaling logic within the `exportSinopticoTabularToPdf` function to address user feedback about the exported table appearing too narrow.

The previous logic would scale the table image down to fit the available page height, which could excessively shrink the width if the table was very long. The new, simplified logic removes this height-based check.

The table image is now always scaled to fit the full available width of the page between the margins. Its height will adjust proportionally. This ensures the table always looks as wide as possible, which was the user's primary requirement.