### PR TITLE
feat: Add checkUserPermission function for role-based access control

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -731,6 +731,69 @@ async function seedDatabase() {
 }
 
 // =================================================================================
+// --- 3.5. CONTROL DE PERMISOS ---
+// =================================================================================
+
+/**
+ * Verifica los permisos de un usuario para realizar una acción específica.
+ * @param {string} action - La acción a verificar (ej: 'create', 'edit', 'delete').
+ * @param {object|string|null} item - El objeto sobre el que se actúa, un string para identificar el tipo (ej: 'tarea'), o null.
+ * @returns {boolean} - `true` si el usuario tiene permiso, `false` en caso contrario.
+ */
+function checkUserPermission(action, item = null) {
+    if (!appState.currentUser) {
+        return false; // Si no hay usuario, no hay permisos.
+    }
+
+    const { role, uid } = appState.currentUser;
+
+    // 1. El rol 'admin' siempre tiene acceso total.
+    if (role === 'admin') {
+        return true;
+    }
+
+    const isTask = (typeof item === 'string' && item === 'tarea') || (item && typeof item === 'object' && 'creatorUid' in item);
+
+    // 2. Lógica específica para Tareas
+    if (isTask) {
+        if (action === 'create') {
+            // Todos los roles pueden crear tareas.
+            return true;
+        }
+        if ((action === 'edit' || action === 'delete') && typeof item === 'object' && item) {
+            // Solo el creador o el asignado pueden editar o eliminar una tarea.
+            return item.creatorUid === uid || item.assigneeUid === uid;
+        }
+    }
+
+    // 3. Lógica para el rol 'lector'
+    if (role === 'lector') {
+        // Los lectores no pueden crear, editar o eliminar nada (excepto la creación de tareas ya manejada).
+        if (['create', 'edit', 'delete'].includes(action)) {
+            return false;
+        }
+    }
+
+    // 4. Lógica para el rol 'editor'
+    if (role === 'editor') {
+        if (action === 'create') {
+            return true; // Los editores pueden crear nuevos elementos.
+        }
+        if (action === 'delete') {
+            return false; // Los editores no pueden eliminar elementos en general.
+        }
+        // Para 'edit', se asume que pueden editar (no hay una regla explícita en contra).
+        // Se podría añadir más lógica aquí si fuera necesario.
+    }
+
+    // Por defecto, permitir otras acciones (como 'view') si no se ha denegado explícitamente.
+    // O podrías devolver 'false' por defecto para una política más restrictiva.
+    // En este caso, asumimos que si no se deniega, se permite.
+    return true;
+}
+
+
+// =================================================================================
 // --- 4. LÓGICA PRINCIPAL DE LA APLICACIÓN (CORE) ---
 // =================================================================================
 


### PR DESCRIPTION
This commit introduces a new function, `checkUserPermission`, in `public/main.js` to handle role-based access control (RBAC) throughout the application.

The function implements the following logic:
- Grants 'admin' users full permissions for all actions.
- Restricts 'lector' (reader) users from performing 'create', 'edit', or 'delete' actions, with an exception for creating tasks.
- Allows 'editor' users to 'create' and 'edit' but not 'delete' in most cases.
- Implements specific logic for tasks, allowing any user to create them, and allowing the creator or assignee to edit or delete them.

This centralized function will serve as the foundation for managing user permissions for various features.