### PR TITLE
Fix admin permissions and UI visibility

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -3,39 +3,40 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
-    function isAdmin() {
-      return request.auth.uid in ['NIFudxxXnea8HqFzeMpxY0kma5b2', '7M6XuPSQf0UHUvet5KnEISxiYBT2', 'KTIQRzPBRcOFtBRjoFViZPSsbSq2'];
+    function isUserAdmin() {
+      // Check if the user has the 'admin' role in their user document.
+      return get(/databases/$(database)/documents/usuarios/$(request.auth.uid)).data.role == 'admin';
     }
 
     // --- USUARIOS ---
     match /usuarios/{userId} {
       // Un usuario puede leer su propio perfil. Los admins pueden leer todos.
-      allow read: if request.auth.uid == userId || isAdmin();
+      allow read: if request.auth.uid == userId || isUserAdmin();
 
       // Un usuario puede crear su propio documento de perfil durante el registro.
       allow create: if request.auth.uid == userId;
 
       // Un usuario puede actualizar su propio perfil (nombre, avatar, etc.).
       // Los administradores pueden actualizar cualquier perfil (para cambiar roles, etc.).
-      allow update: if request.auth.uid == userId || isAdmin();
+      allow update: if request.auth.uid == userId || isUserAdmin();
 
       // Solo los administradores pueden eliminar usuarios.
-      allow delete: if isAdmin();
+      allow delete: if isUserAdmin();
     }
 
     // Reglas para colecciones existentes...
     
-    // Regla para la nueva colección de Unidades de Medida
-    match /unidadesDeMedida/{unidadId} {
+    // Regla para la colección de Unidades de Medida
+    match /unidades/{unidadId} {
       allow read: if request.auth != null;
-      allow write: if isAdmin();
+      allow write: if isUserAdmin();
       allow create: if request.auth != null;
     }
 
     // Regla para la colección de Proveedores
     match /proveedores/{proveedorId} {
       allow read: if request.auth != null;
-      allow write: if isAdmin();
+      allow write: if isUserAdmin();
       allow create: if request.auth != null;
     }
 
@@ -47,7 +48,7 @@ service cloud.firestore {
       // Un usuario puede leer una tarea si es pública, si se le asignó o si la creó.
       // Los administradores pueden leer todas las tareas.
       allow read: if request.auth != null &&
-                    (isAdmin() ||
+                    (isUserAdmin() ||
                      resource.data.isPublic == true ||
                      resource.data.assigneeUid == request.auth.uid ||
                      resource.data.creatorUid == request.auth.uid);
@@ -55,20 +56,20 @@ service cloud.firestore {
       // Un usuario puede actualizar una tarea si se le asignó o si la creó.
       // Los administradores pueden actualizar cualquier tarea.
       allow update: if request.auth != null &&
-                      (isAdmin() ||
+                      (isUserAdmin() ||
                        resource.data.assigneeUid == request.auth.uid ||
                        resource.data.creatorUid == request.auth.uid);
 
       // Un usuario solo puede eliminar una tarea que él mismo creó.
       // Los administradores pueden eliminar cualquier tarea.
       allow delete: if request.auth != null &&
-                      (isAdmin() || resource.data.creatorUid == request.auth.uid);
+                      (isUserAdmin() || resource.data.creatorUid == request.auth.uid);
     }
 
     // El resto de tus reglas
     match /{document=**} {
       allow read: if request.auth != null;
-      allow write: if isAdmin();
+      allow write: if isUserAdmin();
       allow create: if request.auth != null;
     }
   }

--- a/public/main.js
+++ b/public/main.js
@@ -1499,6 +1499,18 @@ function runDashboardLogic() {
     const recentActivity = [...productos, ...insumos]
         .sort((a, b) => (b.createdAt?.seconds || 0) - (a.createdAt?.seconds || 0))
         .slice(0, 5);
+    let adminActionsHTML = '';
+    if (checkUserPermission('delete')) { // Use 'delete' as a proxy for top-level admin actions
+        adminActionsHTML = `
+        <div class="lg:col-span-3 border border-yellow-300 bg-yellow-50 p-6 rounded-xl">
+            <h3 class="text-xl font-bold text-yellow-800 mb-2">Acciones de Administrador</h3>
+            <p class="text-sm text-yellow-700 mb-4">Esta acción borrará todos los datos existentes (excepto usuarios) y los reemplazará con datos de demostración.</p>
+            <button data-action="seed-database" class="bg-yellow-500 text-white px-4 py-2 rounded-md hover:bg-yellow-600 font-semibold">
+                <i data-lucide="database-zap" class="inline-block mr-2 -mt-1"></i>Cargar Datos de Prueba
+            </button>
+        </div>`;
+    }
+
     let content = `<div class="bg-white p-6 rounded-xl shadow-lg animate-fade-in-up">
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <div class="border border-slate-200 p-6 rounded-xl flex items-center space-x-4">
@@ -1541,10 +1553,7 @@ function runDashboardLogic() {
                 `).join('') : `<li class="text-center text-gray-500 py-8">No hay actividad reciente.</li>`}
             </ul>
         </div>
-        <div class="lg:col-span-3 border border-slate-200 p-6 rounded-xl">
-            <h3 class="text-xl font-bold text-gray-800 mb-4">Acciones de Administrador</h3>
-            <button data-action="seed-database" class="bg-yellow-500 text-white px-4 py-2 rounded-md hover:bg-yellow-600">Cargar Datos de Prueba</button>
-        </div>
+        ${adminActionsHTML}
     </div>
     </div>`;
     dom.viewContent.innerHTML = content;


### PR DESCRIPTION
This commit resolves an issue where admin users were not granted the correct permissions, leading to UI inconsistencies and backend errors.

The core problem was a mismatch between the frontend and backend permission models:
- The frontend UI checked for a `role: 'admin'` field in the user's database document.
- The backend Firestore rules used a hardcoded list of admin UIDs.

This led to users with the admin role still being denied write access.

The following changes have been made:
1.  **Unified Permission Model:** The `firestore.rules` have been updated to check the user's role from their document in the `usuarios` collection, making it the single source of truth for permissions.
2.  **Corrected UI Visibility:** The "Load Sample Data" button on the dashboard is now only visible to users with the 'admin' role.
3.  **Fixed Collection Name:** A typo in the `firestore.rules` for the `unidades` collection has been corrected (`unidadesDeMedida` -> `unidades`).