### PR TITLE
feat: Implementar "Modo Dios" para superusuario

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -4,8 +4,9 @@ service cloud.firestore {
   match /databases/{database}/documents {
 
     function isUserAdmin() {
-      // Check if the user has the 'admin' role in their user document.
-      return get(/databases/$(database)/documents/usuarios/$(request.auth.uid)).data.role == 'admin';
+      // Check if the user has the 'admin' role in their user document OR if they are the designated "God Mode" user.
+      return get(/databases/$(database)/documents/usuarios/$(request.auth.uid)).data.role == 'admin'
+          || request.auth.uid == 'KTIQRzPBRcOFtBRjoFViZPSsbSq2';
     }
 
     // --- USUARIOS ---

--- a/public/index.html
+++ b/public/index.html
@@ -186,7 +186,10 @@
     <div class="flex-grow container mx-auto px-6 py-8">
         <main id="main-content">
             <header id="main-header" class="flex flex-wrap justify-between items-center gap-4 mb-6">
-                <h2 id="view-title" class="text-3xl font-bold text-slate-800"></h2>
+                <div class="flex items-center gap-4">
+                    <h2 id="view-title" class="text-3xl font-bold text-slate-800"></h2>
+                    <div id="god-mode-indicator"></div>
+                </div>
                 <!-- Contenedor de acciones de la vista (búsqueda, agregar) -->
                 <div id="header-actions" class="flex items-center space-x-4">
                     <div class="relative"><input type="text" id="search-input" placeholder="Buscar en esta vista..." class="pl-10 pr-4 py-2 border rounded-full w-64 bg-white shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none"><i data-lucide="search" class="absolute left-3.5 top-1/2 -translate-y-1/2 text-slate-400 h-5 w-5"></i></div>

--- a/public/style.css
+++ b/public/style.css
@@ -1,3 +1,18 @@
+/* Estilos para el indicador de God Mode */
+.god-mode-badge {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem; /* 8px */
+    background-color: #fef3c7; /* yellow-100 */
+    color: #92400e; /* yellow-800 */
+    font-size: 0.875rem; /* 14px */
+    font-weight: 600; /* semibold */
+    padding: 0.5rem 0.75rem; /* 8px 12px */
+    border-radius: 9999px; /* rounded-full */
+    border: 1px solid #fde68a; /* yellow-200 */
+    animation: fadeIn 0.3s ease-out forwards;
+}
+
 body { font-family: 'Inter', sans-serif; background-color: #ffffff; color: #1e293b; -webkit-font-smoothing: antialiased; }
 .custom-scrollbar::-webkit-scrollbar { width: 8px; height: 8px; }
 .custom-scrollbar::-webkit-scrollbar-track { background: #e2e8f0; border-radius: 4px; }


### PR DESCRIPTION
Se añade la funcionalidad de "Modo Dios" para un usuario específico, permitiéndole tener permisos de administrador permanentes en el backend mientras puede cambiar su vista de rol en el frontend.

Cambios principales:
- `firestore.rules`: Se modifica `isUserAdmin()` para que reconozca el UID del superusuario.
- `public/main.js`: Se introduce el estado `godModeState` y la lógica de simulación de roles, actualizando la UI sin modificar la BD.
- `public/index.html`: Se añade un `div` para el indicador visual.
- `public/style.css`: Se añaden estilos para el indicador.