### PR TITLE
Fix: Remove duplicate getUniqueKeyForCollection declaration

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -1552,19 +1552,6 @@ async function openFormModal(item = null) {
     });
 }
 
-function getUniqueKeyForCollection(collectionName) {
-    switch (collectionName) {
-        case COLLECTIONS.PRODUCTOS:
-        case COLLECTIONS.SEMITERMINADOS:
-        case COLLECTIONS.INSUMOS:
-            return 'codigo_pieza';
-        case COLLECTIONS.PROYECTOS:
-            return 'codigo';
-        default:
-            return 'id';
-    }
-}
-
 function validateField(fieldConfig, inputElement) {
     const errorElement = document.getElementById(`error-${fieldConfig.key}`);
     let isValid = true;


### PR DESCRIPTION
The function `getUniqueKeyForCollection` was declared in both `public/utils.js` and `public/main.js`. Additionally, `main.js` was importing the function from `utils.js`.

This caused a `SyntaxError: Identifier 'getUniqueKeyForCollection' has already been declared` when the application was loaded.

This commit removes the duplicate function declaration from `public/main.js`, leaving only the imported version from `utils.js` to be used throughout the application.