### PR TITLE
fix: Resolve initial setup errors and sync user profiles

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -57,7 +57,8 @@ service cloud.firestore {
     }
     match /sectores/{docId} {
       allow read: if request.auth != null;
-      allow create, update: if canCreateUpdate();
+      allow create: if request.auth != null;
+      allow update: if canCreateUpdate();
       allow delete: if isUserAdmin();
     }
     match /procesos/{docId} {


### PR DESCRIPTION
Modified Firestore rules to allow any authenticated user to perform the initial creation of default 'sectores'. This resolves the 'Missing or insufficient permissions' error for new users on a clean database.

Implemented a self-healing mechanism in the login flow (`onAuthStateChanged`). If an authenticated user is missing their corresponding document in the `usuarios` Firestore collection, it is now created automatically with a default 'lector' role. This ensures all users are manageable in the admin panel without manual intervention.