### PR TITLE
Fix: Resolve admin creation bootstrap paradox

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -57,8 +57,7 @@ service cloud.firestore {
     }
     match /sectores/{docId} {
       allow read: if request.auth != null;
-      allow create: if request.auth != null;
-      allow update: if canCreateUpdate();
+      allow create, update: if canCreateUpdate();
       allow delete: if isUserAdmin();
     }
     match /procesos/{docId} {

--- a/public/main.js
+++ b/public/main.js
@@ -3365,6 +3365,40 @@ function populateTaskAssigneeDropdown() {
 }
 
 
+async function seedDefaultSectors() {
+    const sectorsRef = collection(db, COLLECTIONS.SECTORES);
+    const snapshot = await getDocs(query(sectorsRef, limit(1)));
+
+    if (!snapshot.empty) {
+        return; // Sectors already exist
+    }
+
+    console.log("No sectors found. Seeding default sectors...");
+    showToast('Creando sectores por defecto...', 'info');
+
+    const defaultSectors = [
+        { id: 'calidad', descripcion: 'Calidad', icon: 'award' },
+        { id: 'produccion', descripcion: 'Producción', icon: 'factory' },
+        { id: 'ingenieria', descripcion: 'Ingeniería', icon: 'pencil-ruler' },
+        { id: 'seguridad-higiene', descripcion: 'Seguridad e Higiene', icon: 'shield-check' }
+    ];
+
+    const batch = writeBatch(db);
+    defaultSectors.forEach(sector => {
+        const docRef = doc(db, COLLECTIONS.SECTORES, sector.id);
+        batch.set(docRef, sector);
+    });
+
+    try {
+        await batch.commit();
+        showToast('Sectores por defecto creados con éxito.', 'success');
+        console.log('Default sectors created successfully.');
+    } catch (error) {
+        console.error("Error seeding default sectors:", error);
+        showToast('Error al crear los sectores por defecto.', 'error');
+    }
+}
+
 onAuthStateChanged(auth, async (user) => {
     if (user) {
         if (user.emailVerified) {


### PR DESCRIPTION
This commit resolves a critical bootstrapping issue where a new user cannot be promoted to an admin role on a fresh database instance.

The problem was a 'chicken-and-egg' scenario:
1. Promoting a user to admin requires selecting a 'sector' from a dropdown in the user management form.
2. The 'sectores' collection, which populates this dropdown, was only created by the database seeder.
3. The seeder could only be run by a user who was already an admin.

This commit introduces a `seedDefaultSectors` function in `public/main.js`. This function runs automatically upon user login, checks if the `sectores` collection is empty, and if so, populates it with a default set of sectors. This ensures the admin creation form is always functional, even on a completely empty database, allowing the first user to be promoted to admin without issue.