### PR TITLE
Hotfix: Remove duplicate function declaration for seedDefaultSectors

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -3726,40 +3726,6 @@ async function logOutUser() {
     }
 }
 
-async function seedDefaultSectors() {
-    const sectorsRef = collection(db, COLLECTIONS.SECTORES);
-    const snapshot = await getDocs(query(sectorsRef, limit(1)));
-
-    if (!snapshot.empty) {
-        return; // Sectors already exist
-    }
-
-    console.log("No sectors found. Seeding default sectors...");
-    showToast('Creando sectores por defecto...', 'info');
-
-    const defaultSectors = [
-        { id: 'calidad', descripcion: 'Calidad', icon: 'award' },
-        { id: 'produccion', descripcion: 'Producción', icon: 'factory' },
-        { id: 'ingenieria', descripcion: 'Ingeniería', icon: 'pencil-ruler' },
-        { id: 'seguridad-higiene', descripcion: 'Seguridad e Higiene', icon: 'shield-check' }
-    ];
-
-    const batch = writeBatch(db);
-    defaultSectors.forEach(sector => {
-        const docRef = doc(db, COLLECTIONS.SECTORES, sector.id);
-        batch.set(docRef, sector);
-    });
-
-    try {
-        await batch.commit();
-        showToast('Sectores por defecto creados con éxito.', 'success');
-        console.log('Default sectors created successfully.');
-    } catch (error) {
-        console.error("Error seeding default sectors:", error);
-        showToast('Error al crear los sectores por defecto.', 'error');
-    }
-}
-
 document.addEventListener('DOMContentLoaded', () => {
     initializeAppListeners();
     lucide.createIcons();


### PR DESCRIPTION
This commit resolves a `SyntaxError: Identifier 'seedDefaultSectors' has already been declared` that was introduced in the previous commit.

The error was caused by an accidental duplication of the `seedDefaultSectors` function in `public/main.js`. This commit removes the extraneous declaration, resolving the error and restoring application functionality.

This change is part of the work to fix the larger admin creation bootstrap paradox.