### PR TITLE
fix: Corrige el error de carga infinita del dashboard

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -217,7 +217,7 @@ let appState = {
         [COLLECTIONS.PRODUCTOS]: [], [COLLECTIONS.SEMITERMINADOS]: [], [COLLECTIONS.INSUMOS]: [], [COLLECTIONS.CLIENTES]: [],
         [COLLECTIONS.SECTORES]: [], [COLLECTIONS.PROCESOS]: [],
         [COLLECTIONS.PROVEEDORES]: [], [COLLECTIONS.UNIDADES]: [],
-        [COLLECTIONS.USUARIOS]: [], [COLLECTIONS.PROYECTOS]: [], [COLLECTIONS.ROLES]: []
+        [COLLECTIONS.USUARIOS]: [], [COLLECTIONS.PROYECTOS]: [], [COLLECTIONS.ROLES]: [], [COLLECTIONS.TAREAS]: []
     },
     collectionsById: {
         [COLLECTIONS.PRODUCTOS]: new Map(),
@@ -230,7 +230,8 @@ let appState = {
         [COLLECTIONS.UNIDADES]: new Map(),
         [COLLECTIONS.USUARIOS]: new Map(),
         [COLLECTIONS.PROYECTOS]: new Map(),
-        [COLLECTIONS.ROLES]: new Map()
+        [COLLECTIONS.ROLES]: new Map(),
+        [COLLECTIONS.TAREAS]: new Map()
     },
     unsubscribeListeners: [],
     sinopticoState: null,


### PR DESCRIPTION
Este commit soluciona un error crítico introducido en el rediseño del dashboard que causaba que la aplicación se quedara atascada en la pantalla de "Cargando datos...".

El problema se debía a que la colección de `tareas` se había añadido a la lista de colecciones esenciales para cargar (`essentialCollections`), pero no se había inicializado en el objeto `appState.collections`. Esto impedía que la promesa de carga de datos se resolviera, bloqueando la inicialización de la aplicación.

La corrección añade la inicialización de `[COLLECTIONS.TAREAS]: []` en el objeto `appState.collections` y `[COLLECTIONS.TAREAS]: new Map()` en `appState.collectionsById`, asegurando que la colección de tareas se cargue correctamente y la aplicación pueda iniciarse.