### PR TITLE
feat: Implement interactivity and persistence for ECO form

### DIFF
--- a/public/utils.js
+++ b/public/utils.js
@@ -10,7 +10,8 @@ export const COLLECTIONS = {
     USUARIOS: 'usuarios',
     TAREAS: 'tareas',
     PROYECTOS: 'proyectos',
-    ROLES: 'roles'
+    ROLES: 'roles',
+    ECO_FORMS: 'eco_forms'
 };
 
 export function getUniqueKeyForCollection(collectionName) {


### PR DESCRIPTION
This commit introduces full functionality to the ECO form.

- Adds real-time saving of form data to Local Storage to prevent data loss on page refresh.
- Implements 'Guardar Progreso' and 'Aprobar ECO' buttons to save the form data to a new `eco_forms` collection in Firestore.
- Creates a `history` subcollection for each form to maintain a complete version history of all modifications.
- Adds a 'Limpiar Formulario' button to clear the form and its local backup.
- Registers the new `eco_forms` collection in the project's utility constants.