### PR TITLE
fix(eco): Add Firestore rules and improve selectors

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -87,6 +87,19 @@ service cloud.firestore {
       allow delete: if isUserAdmin();
     }
 
+    match /eco_forms/{ecoId} {
+      allow read, create, update: if canCreateUpdate();
+      allow delete: if isUserAdmin();
+
+      // History is part of the ECO, should be readable by the same people.
+      // It should only be created, not updated or deleted directly.
+      match /history/{historyId} {
+        allow read: if canCreateUpdate();
+        allow create: if canCreateUpdate();
+        allow update, delete: if false; // Immutable history
+      }
+    }
+
     // --- TAREAS ---
     // Las tareas tienen su propia lógica de permisos más detallada.
     match /tareas/{taskId} {

--- a/public/eco_form.html
+++ b/public/eco_form.html
@@ -22,8 +22,8 @@
 
     <!-- Action Buttons -->
     <div class="mt-8 flex justify-end space-x-4">
-        <button type="button" class="bg-gray-500 text-white px-6 py-2 rounded-md hover:bg-gray-600">Guardar Progreso</button>
-        <button type="button" class="bg-yellow-500 text-white px-6 py-2 rounded-md hover:bg-yellow-600">Limpiar Formulario</button>
-        <button type="button" class="bg-green-500 text-white px-6 py-2 rounded-md hover:bg-green-600">Aprobar ECO</button>
+        <button type="button" id="eco-save-button" class="bg-gray-500 text-white px-6 py-2 rounded-md hover:bg-gray-600">Guardar Progreso</button>
+        <button type="button" id="eco-clear-button" class="bg-yellow-500 text-white px-6 py-2 rounded-md hover:bg-yellow-600">Limpiar Formulario</button>
+        <button type="button" id="eco-approve-button" class="bg-green-500 text-white px-6 py-2 rounded-md hover:bg-green-600">Aprobar ECO</button>
     </div>
 </form>

--- a/public/main.js
+++ b/public/main.js
@@ -1280,9 +1280,9 @@ async function runEcoFormLogic() {
         formElement.addEventListener('input', saveEcoFormToLocalStorage);
 
         // --- Button Logic ---
-        const saveButton = formElement.querySelector('button.bg-gray-500');
-        const clearButton = formElement.querySelector('button.bg-yellow-500');
-        const approveButton = formElement.querySelector('button.bg-green-500');
+        const saveButton = formElement.querySelector('#eco-save-button');
+        const clearButton = formElement.querySelector('#eco-clear-button');
+        const approveButton = formElement.querySelector('#eco-approve-button');
         const ecrInput = formElement.querySelector('#ecr_no');
 
         const getFormData = () => {


### PR DESCRIPTION
Add Firestore security rules for the 'eco_forms' collection to resolve "Missing or insufficient permissions" error when saving or approving an ECO form.

The new rules allow users with 'admin' or 'editor' roles to manage ECO forms.

Refactor ECO form button selectors in main.js to use new IDs instead of CSS classes for improved stability. Add IDs to the corresponding buttons in eco_form.html.