### PR TITLE
fix(eco): Add Firestore rules and fix button selectors

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -1280,9 +1280,9 @@ async function runEcoFormLogic() {
         formElement.addEventListener('input', saveEcoFormToLocalStorage);
 
         // --- Button Logic ---
-        const saveButton = formElement.querySelector('#eco-save-button');
-        const clearButton = formElement.querySelector('#eco-clear-button');
-        const approveButton = formElement.querySelector('#eco-approve-button');
+        const saveButton = document.getElementById('eco-save-button');
+        const clearButton = document.getElementById('eco-clear-button');
+        const approveButton = document.getElementById('eco-approve-button');
         const ecrInput = formElement.querySelector('#ecr_no');
 
         const getFormData = () => {


### PR DESCRIPTION
Add Firestore security rules for the 'eco_forms' collection to resolve "Missing or insufficient permissions" error when saving or approving an ECO form.

Refactor ECO form button selectors in main.js to use getElementById for improved stability and to fix a TypeError on load.

Add IDs to the corresponding buttons in eco_form.html.