### PR TITLE
fix: Use firstElementChild to parse ECO form template

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -1083,7 +1083,7 @@ async function runEcoFormLogic() {
         // Use a template to safely parse the HTML and get a direct reference to the form element
         const template = document.createElement('template');
         template.innerHTML = html.trim();
-        const formElement = template.content.firstChild;
+        const formElement = template.content.firstElementChild;
 
         dom.viewContent.innerHTML = ''; // Clear previous content
         dom.viewContent.appendChild(formElement);


### PR DESCRIPTION
Changed `firstChild` to `firstElementChild` when parsing the fetched HTML for the ECO form.

This prevents a `TypeError` that occurs if the HTML string contains leading whitespace or comments, which would cause `firstChild` to return a text or comment node instead of the expected form element. Using `firstElementChild` ensures the correct element is always selected, making the form loading process more robust.