### PR TITLE
feat: Overhaul ECO module with a dedicated management view

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -141,6 +141,10 @@
                         <i data-lucide="clipboard-check" class="inline-block w-4 h-4 mr-1.5 -mt-0.5"></i>Tareas
                     </a>
 
+                    <a href="#" data-view="ecos" class="nav-link px-4 py-2 rounded-md text-sm font-medium text-slate-700 hover:bg-slate-100">
+                        <i data-lucide="recycle" class="inline-block w-4 h-4 mr-1.5 -mt-0.5"></i>ECOs
+                    </a>
+
                     <!-- Dropdown de Gestión -->
                     <div class="relative nav-dropdown">
                         <button class="nav-link dropdown-toggle px-4 py-2 rounded-md text-sm font-medium text-slate-700 hover:bg-slate-100 flex items-center">
@@ -150,7 +154,6 @@
                         <div class="dropdown-menu absolute mt-2 w-60 bg-white border rounded-lg shadow-xl">
                             <a href="#" data-view="arboles" class="nav-link flex items-center gap-3 px-4 py-3 text-sm hover:bg-slate-100"><i data-lucide="pencil-ruler" class="w-5 h-5 text-slate-500"></i>Editor de Árboles BOM</a>
                             <a href="#" data-view="sinoptico_tabular" class="nav-link flex items-center gap-3 px-4 py-3 text-sm hover:bg-slate-100"><i data-lucide="table" class="w-5 h-5 text-slate-500"></i>Reporte BOM (Tabular)</a>
-                            <a href="#" data-view="eco_form" class="nav-link flex items-center gap-3 px-4 py-3 text-sm hover:bg-slate-100"><i data-lucide="file-text" class="w-5 h-5 text-slate-500"></i>Formulario ECO</a>
                             <div class="border-t my-1"></div>
                             <a href="#" data-view="productos" class="nav-link flex items-center gap-3 px-4 py-3 text-sm hover:bg-slate-100"><i data-lucide="package" class="w-5 h-5 text-slate-500"></i>Productos</a>
                             <a href="#" data-view="proyectos" class="nav-link flex items-center gap-3 px-4 py-3 text-sm hover:bg-slate-100"><i data-lucide="kanban-square" class="w-5 h-5 text-slate-500"></i>Proyectos</a>


### PR DESCRIPTION
This commit introduces a comprehensive overhaul of the ECO (Engineering Change Order) module, moving it from a simple form to a full-featured management section within the application.

Key changes include:

- **New Navigation:** A dedicated "ECOs" link has been added to the main navigation bar, making the module a primary feature of the app. The old link has been removed from the "Gestión" dropdown.

- **ECO Management View:** A new central view for ECOs (`runEcosLogic`) has been created. This view displays a table listing all saved ECOs from Firestore in real-time, showing key details like ECR number, status, and last modification date.

- **View/Edit Functionality:** Users can now click on an ECO in the table to open it in the form view, pre-populated with its data for viewing or editing.

- **History Viewer:** A "View History" button is now available for each ECO, opening a modal that displays a chronological log of all changes made to the document.

- **PDF Export:** A "Export to PDF" feature has been implemented. It generates a PDF of the selected ECO form by rendering it off-screen and capturing it with html2canvas.

- **Code Refactoring:** Shared logic for building and populating the ECO form has been refactored into helper functions to reduce code duplication and improve maintainability.