### PR TITLE
feat: Improve ECO form UX and PDF export

### DIFF
--- a/public/eco_form.html
+++ b/public/eco_form.html
@@ -21,7 +21,7 @@
     </main>
 
     <!-- Action Buttons -->
-    <div class="mt-8 flex justify-end space-x-4">
+    <div id="action-buttons-container" class="mt-8 flex justify-end space-x-4">
         <button type="button" id="eco-save-button" class="bg-gray-500 text-white px-6 py-2 rounded-md hover:bg-gray-600">Guardar Progreso</button>
         <button type="button" id="eco-clear-button" class="bg-yellow-500 text-white px-6 py-2 rounded-md hover:bg-yellow-600">Limpiar Formulario</button>
         <button type="button" id="eco-approve-button" class="bg-green-500 text-white px-6 py-2 rounded-md hover:bg-green-600">Aprobar ECO</button>

--- a/public/main.js
+++ b/public/main.js
@@ -1330,13 +1330,14 @@ async function runEcoFormLogic(params = null) {
         const approveButton = document.getElementById('eco-approve-button');
         const ecrInput = formElement.querySelector('#ecr_no');
 
+        // Always add a "Back" button
+        const backButtonHTML = `<button type="button" id="eco-back-button" class="bg-gray-200 text-gray-800 px-6 py-2 rounded-md hover:bg-gray-300">Volver a la Lista</button>`;
+        saveButton.insertAdjacentHTML('beforebegin', backButtonHTML);
+        document.getElementById('eco-back-button').addEventListener('click', () => switchView('ecos'));
+
         if (isEditing) {
             ecrInput.readOnly = true;
             ecrInput.classList.add('bg-gray-100', 'cursor-not-allowed');
-            // Add a "Back" button
-            const backButtonHTML = `<button type="button" id="eco-back-button" class="bg-gray-200 text-gray-800 px-6 py-2 rounded-md hover:bg-gray-300">Volver a la Lista</button>`;
-            saveButton.insertAdjacentHTML('beforebegin', backButtonHTML);
-            document.getElementById('eco-back-button').addEventListener('click', () => switchView('ecos'));
         }
 
         if (ecoId) {
@@ -1887,6 +1888,21 @@ async function exportEcoToPdf(ecoId) {
                 const styleSheet = document.getElementById('eco-form-styles');
                 if (styleSheet) {
                     clonedDoc.head.appendChild(styleSheet.cloneNode(true));
+                }
+
+                // Ocultar botones de acción para el PDF
+                const buttonContainer = clonedDoc.getElementById('action-buttons-container');
+                if (buttonContainer) {
+                    buttonContainer.style.display = 'none';
+                }
+
+                // Hacer que el input ECR N° parezca texto plano
+                const ecrInput = clonedDoc.getElementById('ecr_no');
+                if (ecrInput) {
+                    ecrInput.style.border = 'none';
+                    ecrInput.style.background = 'transparent';
+                    ecrInput.style.paddingLeft = '0';
+                    ecrInput.setAttribute('readonly', 'true');
                 }
             }
         });


### PR DESCRIPTION
This commit addresses user feedback on the ECO form page by:

- Always displaying a "Back to List" button on the ECO form for consistent navigation.
- Hiding action buttons in the exported PDF to create a cleaner document.
- Styling the ECR number input as static text in the PDF for a more professional appearance.