### PR TITLE
feat: Implement centralized Master Cover for ECR/ECO

### DIFF
--- a/public/eco_form.html
+++ b/public/eco_form.html
@@ -1,18 +1,12 @@
 <form id="eco-form" class="max-w-7xl mx-auto bg-white shadow-lg rounded-lg p-8">
     <!-- Encabezado -->
-    <header class="flex justify-between items-start border-b-2 pb-4">
-        <div class="flex items-center">
-            <div class="w-24 h-24 flex items-center justify-center">
-                <img src="barack_logo.png" alt="Logo">
-            </div>
-            <div class="ml-4">
-                <h1 class="text-2xl font-bold text-gray-800">ECO DE PRODUCTO / PROCESO</h1>
-                <p class="text-sm text-gray-600">I-IN-003.1 ECR - ECO B</p>
-            </div>
-        </div>
-        <div class="flex items-center">
+    <header class="flex justify-between items-center border-b-2 pb-4 mb-6">
+        <div>
             <label for="ecr_no" class="text-lg font-semibold mr-2">ECR N°:</label>
             <input type="text" id="ecr_no" name="ecr_no" class="border-2 border-gray-300 rounded-md p-2 w-48">
+        </div>
+        <div id="eco-header-actions" class="flex items-center gap-2">
+            <!-- Buttons will be inserted here by JS -->
         </div>
     </header>
 
@@ -24,7 +18,6 @@
     <div id="action-buttons-container" class="mt-8 flex justify-end space-x-4">
         <button type="button" id="eco-save-button" class="bg-gray-500 text-white px-6 py-2 rounded-md hover:bg-gray-600">Guardar Progreso</button>
         <button type="button" id="eco-clear-button" class="bg-yellow-500 text-white px-6 py-2 rounded-md hover:bg-yellow-600">Limpiar Formulario</button>
-        <button type="button" id="eco-approve-button" class="bg-green-500 text-white px-6 py-2 rounded-md hover:bg-green-600">Aprobar ECO</button>
     </div>
 </form>
 <link rel="stylesheet" href="print.css" media="print">

--- a/public/index.html
+++ b/public/index.html
@@ -170,6 +170,7 @@
                         </button>
                         <div class="dropdown-menu absolute mt-2 w-56 bg-white border rounded-lg shadow-xl">
                             <a href="#" data-view="user_management" class="nav-link flex items-center gap-3 px-4 py-3 text-sm hover:bg-slate-100"><i data-lucide="user-cog" class="w-5 h-5 text-slate-500"></i>Usuarios</a>
+                            <a href="#" data-view="cover_master" class="nav-link flex items-center gap-3 px-4 py-3 text-sm hover:bg-slate-100"><i data-lucide="file-check-2" class="w-5 h-5 text-slate-500"></i>Carátula Maestra</a>
                              <div class="border-t my-1"></div>
                             <a href="#" data-view="clientes" class="nav-link flex items-center gap-3 px-4 py-3 text-sm hover:bg-slate-100"><i data-lucide="users" class="w-5 h-5 text-slate-500"></i>Clientes</a>
                             <a href="#" data-view="proveedores" class="nav-link flex items-center gap-3 px-4 py-3 text-sm hover:bg-slate-100"><i data-lucide="truck" class="w-5 h-5 text-slate-500"></i>Proveedores</a>

--- a/public/utils.js
+++ b/public/utils.js
@@ -11,7 +11,8 @@ export const COLLECTIONS = {
     TAREAS: 'tareas',
     PROYECTOS: 'proyectos',
     ROLES: 'roles',
-    ECO_FORMS: 'eco_forms'
+    ECO_FORMS: 'eco_forms',
+    COVER_MASTER: 'cover_master'
 };
 
 export function getUniqueKeyForCollection(collectionName) {


### PR DESCRIPTION
This commit introduces a centralized 'Master Cover' system for ECR/ECO documents, refactoring the previous hardcoded implementation into a dynamic, version-controlled feature.

Key changes:
- A new Firestore collection `cover_master` now stores a single, editable master cover document.
- A dedicated admin view ('Editar Carátula Maestra') allows authorized users to modify the master cover.
- Saving the master cover automatically increments its revision letter (A, B, C...) and creates a history entry with a timestamp, user, and description of the change.
- The ECO form view has been updated to remove the old static header. It now includes buttons to view the current master cover and its revision history in a modal.
- The PDF export functionality has been completely refactored. It now generates a multi-page PDF where the first page is a dynamically rendered view of the current master cover, followed by the specific ECO content.
- The 'Approve ECO' button has been moved from the form to the list view of all ECOs for better contextual separation.