### PR TITLE
feat: Implement centralized Master Cover for ECR/ECO

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -100,6 +100,31 @@ service cloud.firestore {
       }
     }
 
+    // --- CARÁTULA MAESTRA ---
+    match /cover_master/{docId} {
+      // Anyone authenticated can read the master cover.
+      allow read: if request.auth != null;
+
+      // Only admins can create or update the master cover.
+      // We only expect one document with id 'master'.
+      allow create, update: if isUserAdmin();
+
+      // The master cover should not be deleted.
+      allow delete: if false;
+
+      // History for the master cover
+      match /history/{historyId} {
+        // Anyone authenticated can read the history.
+        allow read: if request.auth != null;
+
+        // Only admins can create history entries (done via transaction).
+        allow create: if isUserAdmin();
+
+        // History is immutable.
+        allow update, delete: if false;
+      }
+    }
+
     // --- TAREAS ---
     // Las tareas tienen su propia lógica de permisos más detallada.
     match /tareas/{taskId} {


### PR DESCRIPTION
This commit introduces a centralized 'Master Cover' system for ECR/ECO documents, refactoring the previous hardcoded implementation into a dynamic, version-controlled feature.

Key changes:
- A new Firestore collection `cover_master` now stores a single, editable master cover document.
- A dedicated admin view ('Editar Carátula Maestra') allows authorized users to modify the master cover.
- Saving the master cover automatically increments its revision letter (A, B, C...) and creates a history entry with a timestamp, user, and description of the change.
- The ECO form view has been updated to remove the old static header. It now includes buttons to view the current master cover and its revision history in a modal.
- The PDF export functionality has been completely refactored. It now generates a multi-page PDF where the first page is a dynamically rendered view of the current master cover, followed by the specific ECO content.
- The 'Approve ECO' button has been moved from the form to the list view of all ECOs for better contextual separation.
- Firestore security rules have been added for the new `cover_master` collection to ensure only authenticated users can read and only admins can write.