### PR TITLE
feat: Implement centralized Master Cover for ECR/ECO

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -88,13 +88,14 @@ service cloud.firestore {
     }
 
     match /eco_forms/{ecoId} {
-      allow read, create, update: if canCreateUpdate();
+      allow read: if request.auth != null;
+      allow create, update: if canCreateUpdate();
       allow delete: if isUserAdmin();
 
       // History is part of the ECO, should be readable by the same people.
       // It should only be created, not updated or deleted directly.
       match /history/{historyId} {
-        allow read: if canCreateUpdate();
+        allow read: if request.auth != null;
         allow create: if canCreateUpdate();
         allow update, delete: if false; // Immutable history
       }


### PR DESCRIPTION
This commit introduces a centralized 'Master Cover' system for ECR/ECO documents, refactoring the previous hardcoded implementation into a dynamic, version-controlled feature.

Key changes:
- A new Firestore collection `cover_master` now stores a single, editable master cover document.
- A dedicated admin view ('Editar Carátula Maestra') allows authorized users to modify the master cover.
- Saving the master cover automatically increments its revision letter (A, B, C...) and creates a history entry with a timestamp, user, and description of the change.
- The ECO form view has been updated to remove the old static header. It now includes buttons to view the current master cover and its revision history in a modal.
- The PDF export functionality has been completely refactored. It now generates a multi-page PDF where the first page is a dynamically rendered view of the current master cover, followed by the specific ECO content.
- The 'Approve ECO' button has been moved from the form to the list view of all ECOs for better contextual separation.
- Firestore security rules have been added for the new `cover_master` collection and corrected for `eco_forms` to ensure proper read/write access for different user roles.