### PR TITLE
Fix Firestore permission error for new users

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -4,14 +4,23 @@ service cloud.firestore {
   match /databases/{database}/documents {
 
     function isUserAdmin() {
-      // Check if the user has the 'admin' role in their user document OR if they are the designated "God Mode" user.
-      return get(/databases/$(database)/documents/usuarios/$(request.auth.uid)).data.role == 'admin'
-          || request.auth.uid == 'KTIQRzPBRcOFtBRjoFViZPSsbSq2';
+      // First, check for Super Admin UID to avoid unnecessary reads, which would fail for a new user.
+      if (request.auth.uid == 'KTIQRzPBRcOFtBRjoFViZPSsbSq2') {
+        return true;
+      }
+      // For other users, check if their user document exists before trying to read the role.
+      let userDocPath = /databases/$(database)/documents/usuarios/$(request.auth.uid);
+      return exists(userDocPath) && get(userDocPath).data.role == 'admin';
     }
 
     function canCreateUpdate() {
-      let userRole = get(/databases/$(database)/documents/usuarios/$(request.auth.uid)).data.role;
-      return isUserAdmin() || userRole == 'editor';
+      // isUserAdmin() is now safe to call for any user, as it handles non-existent documents.
+      if (isUserAdmin()) {
+        return true;
+      }
+      // If not an admin, we can safely check for the 'editor' role.
+      let userDocPath = /databases/$(database)/documents/usuarios/$(request.auth.uid);
+      return exists(userDocPath) && get(userDocPath).data.role == 'editor';
     }
 
     // --- USUARIOS ---


### PR DESCRIPTION
The application was throwing a "Missing or insufficient permissions" error during the first login on a clean database. This was caused by a deadlock in the Firestore security rules.

The `isUserAdmin` and `canCreateUpdate` functions were attempting to read the `role` from a user's document before that document was created. This read on a non-existent document caused the rule evaluation to fail, blocking the initial data seeding required to create the user document.

This commit makes the security rules more robust by:
- In `isUserAdmin`, checking for the Super Admin UID before attempting any database read.
- Adding `exists()` checks before any `get()` call on a user document in both `isUserAdmin` and `canCreateUpdate` functions.

This ensures that the rules no longer fail for new users and allows the initial login and data seeding process to complete successfully.