### PR TITLE
Fix ECO form loading and improve Task Manager stability

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -1463,9 +1463,9 @@ async function runEcoFormLogic(params = null) {
         }
 
         // --- Button Logic ---
-        const saveButton = document.getElementById('eco-save-button');
-        const approveButton = document.getElementById('eco-approve-button');
-        const clearButton = document.getElementById('eco-clear-button');
+        const saveButton = formElement.querySelector('#eco-save-button');
+        const approveButton = formElement.querySelector('#eco-approve-button');
+        const clearButton = formElement.querySelector('#eco-clear-button');
         const ecrInput = formElement.querySelector('#ecr_no');
         const headerActions = formElement.querySelector('#eco-header-actions');
 


### PR DESCRIPTION
This commit addresses two issues:

1.  **Fixes a TypeError in the ECO form loading logic.**
    - The root cause was that the script was trying to find form elements in the global `document` before they were guaranteed to be rendered.
    - The fix refactors `runEcoFormLogic` to consistently use `formElement.querySelector` to find elements within the scope of the newly loaded form content. This makes the logic more robust and resilient to DOM timing issues.
    - This also resolves the user's observation that the 'caratula' (cover sheet) buttons were not appearing.

2.  **Proactively improves Task Manager rendering.**
    - Based on a review of intermittent failures, the `renderTasks` function call inside `fetchAndRenderTasks` is now wrapped in a `setTimeout(..., 0)`.
    - This defers rendering to the next event loop cycle, preventing potential race conditions where the Kanban board DOM might not be fully ready when the rendering function is called.