### PR TITLE
fix: Correct DOM selector for ECO form logic

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -1428,7 +1428,7 @@ async function runEcoFormLogic(params = null) {
             </div>`;
         }
 
-        const container = document.getElementById('dynamic-form-sections');
+        const container = formElement.querySelector('#dynamic-form-sections');
         if (container) {
             formSectionsData.forEach(section => {
                 const sectionHTML = buildSectionHTML(section);


### PR DESCRIPTION
- The `runEcoFormLogic` function was attempting to find the `#dynamic-form-sections` element using `document.getElementById` immediately after creating the form element in memory.
- This caused a race condition where the script would sometimes execute before the main DOM was updated, resulting in a `null` reference and a `TypeError` when trying to add an event listener.
- The fix changes the selector to `formElement.querySelector`, scoping the search to the newly created and referenced form element, which ensures the container is found and resolves the error.