### PR TITLE
Fix: Resolve ECO form loading error

### DIFF
--- a/public/eco_form.html
+++ b/public/eco_form.html
@@ -18,4 +18,3 @@
         <button type="button" id="eco-approve-button" class="bg-green-600 text-white px-6 py-2 rounded-md hover:bg-green-700">Aprobar y Guardar</button>
     </div>
 </form>
-<link rel="stylesheet" href="print.css" media="print">

--- a/public/main.js
+++ b/public/main.js
@@ -1188,6 +1188,15 @@ async function runEcoFormLogic(params = null) {
             document.head.appendChild(link);
         }
 
+        if (!document.getElementById('print-styles')) {
+            const link = document.createElement('link');
+            link.id = 'print-styles';
+            link.rel = 'stylesheet';
+            link.href = 'print.css';
+            link.media = 'print';
+            document.head.appendChild(link);
+        }
+
         const formSectionsData = [
             {
                 title: 'ENG. PRODUCTO',
@@ -1553,8 +1562,10 @@ async function runEcoFormLogic(params = null) {
         });
 
         appState.currentViewCleanup = () => {
-            const style = document.getElementById('eco-form-styles');
-            if(style) style.remove();
+            const ecoStyle = document.getElementById('eco-form-styles');
+            if(ecoStyle) ecoStyle.remove();
+            const printStyle = document.getElementById('print-styles');
+            if(printStyle) printStyle.remove();
             formElement.removeEventListener('input', saveEcoFormToLocalStorage);
         };
 


### PR DESCRIPTION
This commit fixes a `TypeError: Cannot read properties of null (reading 'addEventListener')` that occurred when loading the ECO form.

The root cause was an out-of-place `<link>` tag at the end of `eco_form.html`, which interfered with the browser's dynamic HTML parsing.

The fix involves:
1.  Removing the `<link>` tag from `public/eco_form.html`.
2.  Dynamically injecting the print stylesheet into the document head from within the `runEcoFormLogic` function in `public/main.js`.
3.  Adding a corresponding cleanup task to remove the stylesheet when the view is changed.

This ensures the form's HTML is parsed predictably, allowing the JavaScript to find all necessary elements and attach event listeners correctly.