### PR TITLE
Fix ECO form and export layout

### DIFF
--- a/public/eco_form.html
+++ b/public/eco_form.html
@@ -1,6 +1,7 @@
 <form id="eco-form" class="max-w-7xl mx-auto bg-white shadow-lg rounded-lg p-8">
     <!-- Encabezado -->
     <header class="flex justify-between items-center border-b-2 pb-4 mb-6">
+        <img src="barack_logo.png" alt="Logo" class="h-12">
         <div>
             <label for="ecr_no" class="text-lg font-semibold mr-2">ECR N°:</label>
             <input type="text" id="ecr_no" name="ecr_no" class="border-2 border-gray-300 rounded-md p-2 w-48">

--- a/public/main.js
+++ b/public/main.js
@@ -1941,15 +1941,19 @@ async function exportEcoToPdf(ecoId) {
 
         // Header
         if (logoBase64) {
-            pdf.addImage(logoBase64, 'PNG', MARGIN, y, 40, 20);
+            pdf.addImage(logoBase64, 'PNG', MARGIN, y, 35, 15);
         }
-        pdf.setFontSize(22);
         pdf.setFont('helvetica', 'bold');
-        pdf.text('ECO DE PRODUCTO / PROCESO', PAGE_WIDTH / 2, y + 10, { align: 'center' });
+        pdf.setFontSize(16);
+        const title = 'ECO DE PRODUCTO / PROCESO';
+        const ecrText = `ECR N°: ${ecoData.id || 'N/A'}`;
 
+        // Draw title and ECR number right-aligned
+        pdf.text(title, PAGE_WIDTH - MARGIN, y + 8, { align: 'right' });
         pdf.setFontSize(12);
         pdf.setFont('helvetica', 'normal');
-        pdf.text(`ECR N°: ${ecoData.id || 'N/A'}`, PAGE_WIDTH / 2, y + 18, { align: 'center' });
+        pdf.text(ecrText, PAGE_WIDTH - MARGIN, y + 16, { align: 'right' });
+
         y += 30;
 
 


### PR DESCRIPTION
This commit addresses several layout issues in the ECO/ECR functionality.

- In the ECO form (`eco_form.html`), a logo has been added to the header and the ECR number input has been moved to the right for better visual organization.
- In the PDF export (`main.js`), the title font size has been reduced and the header text has been right-aligned to prevent it from overlapping with the logo.