### PR TITLE
Improve ECO form and PDF export

### DIFF
--- a/public/eco_form.html
+++ b/public/eco_form.html
@@ -1,7 +1,7 @@
 <form id="eco-form" class="max-w-7xl mx-auto bg-white shadow-lg rounded-lg p-8">
     <!-- Encabezado -->
     <header class="flex justify-between items-center border-b-2 pb-4 mb-6">
-        <img src="barack_logo.png" alt="Logo" class="h-12">
+        <img src="/barack_logo.png" alt="Logo" class="h-12">
         <div>
             <label for="ecr_no" class="text-lg font-semibold mr-2">ECR N°:</label>
             <input type="text" id="ecr_no" name="ecr_no" class="border-2 border-gray-300 rounded-md p-2 w-48">


### PR DESCRIPTION
This commit addresses follow-up feedback on the ECO/ECR functionality.

- The logo path in `eco_form.html` is changed to an absolute path to ensure it always loads correctly.
- The `exportEcoToPdf` function in `main.js` is refactored to prevent sections from being split across pages. This is achieved by pre-calculating the height of each section before drawing it.