### PR TITLE
Fix ECR form alignment and data seeding bugs

### DIFF
--- a/public/ecr_form.css
+++ b/public/ecr_form.css
@@ -140,6 +140,41 @@ body {
     align-items: center;
 }
 
+/* New Grid Layout for ECR Objectives section */
+.ecr-grid-section {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    border: 1px solid black;
+    border-radius: 4px;
+    margin-top: 1rem;
+    overflow: hidden; /* Ensures the border-radius is respected by children */
+}
+
+.ecr-grid-header {
+    background-color: #e5e7eb; /* gray-200 */
+    font-weight: bold;
+    padding: 4px 6px;
+    border-bottom: 1px solid black;
+    text-align: center;
+}
+
+/* Add border to all but the last header */
+.ecr-grid-header:not(:last-child) {
+    border-right: 1px solid black;
+}
+
+.ecr-grid-cell {
+    padding: 6px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem; /* Same as checkbox-group for consistency */
+}
+
+/* Add border to all but the last cell in a row */
+.ecr-grid-cell:not(:last-child) {
+    border-right: 1px solid black;
+}
+
 /* Two-column layout for "Situacion" */
 .two-column-layout {
     display: grid;

--- a/public/main.js
+++ b/public/main.js
@@ -558,8 +558,9 @@ function deleteItem(docId) {
 async function clearDataOnly() {
     showToast('Limpiando colecciones de datos...', 'info', 5000);
     const collectionNames = Object.values(COLLECTIONS);
+    const collectionsToSkip = [COLLECTIONS.USUARIOS, COLLECTIONS.TAREAS, COLLECTIONS.COVER_MASTER];
     for (const name of collectionNames) {
-        if (name === COLLECTIONS.USUARIOS || name === COLLECTIONS.TAREAS) {
+        if (collectionsToSkip.includes(name)) {
             console.log(`Se omite la limpieza de la colección '${name}' para preservar los datos.`);
             continue;
         }
@@ -866,6 +867,7 @@ async function seedDatabase() {
 
     // --- GENERACIÓN DE PRODUCTOS Y ESTRUCTURAS ---
     showToast(`Generando ${TOTAL_PRODUCTS} productos con estructura...`, 'info');
+    generated.productos = []; // Make sure to initialize the array
 
     for (let i = 1; i <= TOTAL_PRODUCTS; i++) {
         const productId = `PROD${String(i).padStart(4, '0')}`;
@@ -918,6 +920,7 @@ async function seedDatabase() {
 
         buildTree(rootNode, 1);
         productoData.estructura = [rootNode];
+        generated.productos.push(productoData); // This line was missing
         setInBatch(COLLECTIONS.PRODUCTOS, productoData);
     }
 
@@ -2041,14 +2044,14 @@ async function runEcrFormLogic(params = null) {
                 ${createTextField('Denominación del Producto:', 'denominacion_producto', '...', true)}
             </section>
 
-            <table class="full-width-table mt-4">
-                <thead><tr><th style="width: 33.33%;">OBJETIVO DE ECR</th><th style="width: 33.33%;">TIPO DE ALTERACIÓN</th><th style="width: 33.33%;">AFECTA S/R</th></tr></thead>
-                <tbody><tr>
-                    <td><div class="flex flex-col gap-2">${['Productividad', 'Mejora de calidad', 'Estrategia del Cliente', 'Estrategia Barack', 'Nacionalización'].map(l => createCheckbox(l, `obj_${l.toLowerCase().replace(/ /g,'_')}`)).join('')}</div></td>
-                    <td><div class="flex flex-col gap-2">${['Producto', 'Proceso', 'Fuente de suministro', 'Embalaje'].map(l => createCheckbox(l, `tipo_${l.toLowerCase().replace(/ /g,'_')}`)).join('')} <div class="flex items-center gap-2 mt-1"><input type="checkbox" id="tipo_otro" name="tipo_otro"><label for="tipo_otro" class="text-sm">Otro:</label><input name="tipo_otro_text" type="text" class="border-b-2 bg-transparent flex-grow"></div></div></td>
-                    <td><div class="flex flex-col gap-2">${['Relocalización de Planta', 'Modificación de Layout', 'Modificación de herramental'].map(l => createCheckbox(l, `afecta_${l.toLowerCase().replace(/ /g,'_')}`)).join('')}</div></td>
-                </tr></tbody>
-            </table>
+            <div class="ecr-grid-section">
+                <div class="ecr-grid-header">OBJETIVO DE ECR</div>
+                <div class="ecr-grid-header">TIPO DE ALTERACIÓN</div>
+                <div class="ecr-grid-header">AFECTA S/R</div>
+                <div class="ecr-grid-cell">${['Productividad', 'Mejora de calidad', 'Estrategia del Cliente', 'Estrategia Barack', 'Nacionalización'].map(l => createCheckbox(l, `obj_${l.toLowerCase().replace(/ /g,'_')}`)).join('')}</div>
+                <div class="ecr-grid-cell">${['Producto', 'Proceso', 'Fuente de suministro', 'Embalaje'].map(l => createCheckbox(l, `tipo_${l.toLowerCase().replace(/ /g,'_')}`)).join('')} <div class="flex items-center gap-2 mt-1"><input type="checkbox" id="tipo_otro" name="tipo_otro"><label for="tipo_otro" class="text-sm">Otro:</label><input name="tipo_otro_text" type="text" class="border-b-2 bg-transparent flex-grow"></div></div>
+                <div class="ecr-grid-cell">${['Relocalización de Planta', 'Modificación de Layout', 'Modificación de herramental'].map(l => createCheckbox(l, `afecta_${l.toLowerCase().replace(/ /g,'_')}`)).join('')}</div>
+            </div>
 
             <div class="two-column-layout mt-4">
                 <div class="column-box"><h3>SITUACIÓN EXISTENTE:</h3>${createTextarea('situacion_existente')}</div>


### PR DESCRIPTION
- Refactored a section of the ECR form from a table to a CSS grid layout to ensure proper alignment of columns.
- Added corresponding styles for the new grid layout in `ecr_form.css`.
- Fixed a bug in `clearDataOnly` that caused a permission error by preventing it from attempting to clear system collections like `cover_master`.
- Fixed a TypeError in `seedDatabase` by ensuring the `generated.productos` array is correctly populated before being used by `seedEcrs`.
- Kept the task generation in `seedDatabase` commented out as per the user's request.