### PR TITLE
Fix ECR form alignment and data seeding bugs

### DIFF
--- a/public/ecr_form.css
+++ b/public/ecr_form.css
@@ -144,35 +144,27 @@ body {
 .ecr-grid-section {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
+    gap: 1px; /* This will create the "border" lines */
     border: 1px solid black;
     border-radius: 4px;
     margin-top: 1rem;
     overflow: hidden; /* Ensures the border-radius is respected by children */
+    background-color: black; /* This color will show through the gaps */
 }
 
 .ecr-grid-header {
     background-color: #e5e7eb; /* gray-200 */
     font-weight: bold;
-    padding: 4px 6px;
-    border-bottom: 1px solid black;
+    padding: 8px 6px; /* Increased padding */
     text-align: center;
 }
 
-/* Add border to all but the last header */
-.ecr-grid-header:not(:last-child) {
-    border-right: 1px solid black;
-}
-
 .ecr-grid-cell {
-    padding: 6px;
+    background-color: white;
+    padding: 12px; /* Increased padding */
     display: flex;
     flex-direction: column;
-    gap: 0.5rem; /* Same as checkbox-group for consistency */
-}
-
-/* Add border to all but the last cell in a row */
-.ecr-grid-cell:not(:last-child) {
-    border-right: 1px solid black;
+    gap: 0.75rem; /* Increased gap */
 }
 
 /* Two-column layout for "Situacion" */


### PR DESCRIPTION
- Refactored a section of the ECR form from a table to a CSS grid layout to ensure proper alignment of columns and added more spacing as requested.
- Added corresponding styles for the new grid layout in `ecr_form.css`.
- Fixed a bug in `clearDataOnly` that caused a permission error by preventing it from attempting to clear system collections like `cover_master`.
- Fixed a TypeError in `seedDatabase` by ensuring the `generated.productos` array is correctly populated before being used by `seedEcrs`.
- Kept the task generation in `seedDatabase` commented out as per the user's request.