### PR TITLE
feat: Rediseño completo del Panel de Control

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -144,15 +144,13 @@
                     <!-- Dropdown de ECO/ECR -->
                     <div class="relative nav-dropdown">
                         <button class="nav-link dropdown-toggle px-4 py-2 rounded-md text-sm font-medium text-slate-700 hover:bg-slate-100 flex items-center">
-                            <i data-lucide="file-stack" class="inline-block w-4 h-4 mr-1.5 -mt-0.5"></i>ECO/ECR
+                            <i data-lucide="layout-dashboard" class="inline-block w-4 h-4 mr-1.5 -mt-0.5"></i>ECO/ECR
                             <i data-lucide="chevron-down" class="w-4 h-4 ml-1"></i>
                         </button>
                         <div class="dropdown-menu absolute mt-2 w-72 bg-white border rounded-lg shadow-xl">
-                            <a href="#" data-view="eco" class="nav-link flex items-center gap-3 px-4 py-3 text-sm hover:bg-slate-100"><i data-lucide="recycle" class="w-5 h-5 text-slate-500"></i>ECO</a>
-                            <a href="#" data-view="ecr" class="nav-link flex items-center gap-3 px-4 py-3 text-sm hover:bg-slate-100"><i data-lucide="file-plus-2" class="w-5 h-5 text-slate-500"></i>ECR</a>
-                            <div class="border-t my-1"></div>
-                            <a href="#" data-view="control_ecrs" class="nav-link flex items-center gap-3 px-4 py-3 text-sm hover:bg-slate-100"><i data-lucide="table-properties" class="w-5 h-5 text-slate-500"></i>PANEL de control</a>
-                            <a href="#" data-view="indicadores_ecr" class="nav-link flex items-center gap-3 px-4 py-3 text-sm hover:bg-slate-100"><i data-lucide="bar-chart-3" class="w-5 h-5 text-slate-500"></i>Indicadores</a>
+                            <a href="#" data-view="control_ecrs" class="nav-link flex items-center gap-3 px-4 py-3 text-sm hover:bg-slate-100">
+                                <i data-lucide="layout-dashboard" class="w-5 h-5 text-slate-500"></i>Panel de Control
+                            </a>
                         </div>
                     </div>
                     <!-- Dropdown de Gestión -->

--- a/public/main.js
+++ b/public/main.js
@@ -59,8 +59,7 @@ const viewConfig = {
     eco: { title: 'Gestión de ECO', singular: 'ECO' },
     ecr_form: { title: 'ECR de Producto / Proceso', singular: 'ECR Form' },
     ecr: { title: 'Gestión de ECR', singular: 'ECR' },
-    control_ecrs: { title: 'PANEL de control', singular: 'Control ECR' },
-    indicadores_ecr: { title: 'Indicadores ECO/ECR', singular: 'Indicador' },
+    control_ecrs: { title: 'Panel de Control', singular: 'Panel de Control' },
     flujograma: { title: 'Flujograma de Procesos', singular: 'Flujograma' },
     arboles: { title: 'Editor de Árboles', singular: 'Árbol' },
     profile: { title: 'Mi Perfil', singular: 'Mi Perfil' },
@@ -1152,7 +1151,6 @@ function switchView(viewName, params = null) {
     else if (viewName === 'eco') runEcoLogic();
     else if (viewName === 'ecr') runEcrLogic();
     else if (viewName === 'control_ecrs') runControlEcrsLogic();
-    else if (viewName === 'indicadores_ecr') runIndicadoresEcrLogic();
     else if (viewName === 'eco_form') runEcoFormLogic(params);
     else if (viewName === 'ecr_form') runEcrFormLogic(params);
     else if (config?.dataKey) {
@@ -1967,24 +1965,25 @@ const createDashboardChartConfig = (type, labels, data, title) => ({
 });
 
 
-async function runIndicadoresEcrLogic() {
+async function runControlEcrsLogic() {
     dom.headerActions.style.display = 'none';
-    let activeDashboardUnsub = null;
     let ecrChart = null;
     let ecoChart = null;
+    let obsoletosChart = null;
+    let activeUnsubscribes = [];
 
     const cleanup = () => {
         if (ecrChart) ecrChart.destroy();
         if (ecoChart) ecoChart.destroy();
+        if (obsoletosChart) obsoletosChart.destroy();
         ecrChart = null;
         ecoChart = null;
-        if (activeDashboardUnsub) {
-            activeDashboardUnsub();
-            activeDashboardUnsub = null;
-        }
+        obsoletosChart = null;
+        activeUnsubscribes.forEach(unsub => unsub());
+        activeUnsubscribes = [];
     };
 
-    const renderIndicadorEcmView = () => {
+    const renderDashboard = () => {
         cleanup();
         const currentYear = new Date().getFullYear();
         let yearOptions = '';
@@ -1995,17 +1994,12 @@ async function runIndicadoresEcrLogic() {
 
         const viewHTML = `
             <div class="animate-fade-in space-y-8">
-                <div class="flex justify-between items-center">
-                     <div>
-                        <button data-action="back-to-hub" class="flex items-center gap-2 text-sm font-semibold text-slate-600 hover:text-slate-800 mb-2">
-                            <i data-lucide="arrow-left" class="w-4 h-4"></i>
-                            Volver al Panel de Indicadores
-                        </button>
-                        <h2 class="text-3xl font-bold text-slate-800">Indicador ECM</h2>
-                    </div>
+                <!-- Header -->
+                <div class="flex flex-col md:flex-row justify-between items-center gap-4">
+                     <h2 class="text-3xl font-bold text-slate-800">Panel de Control de Indicadores ECO/ECR</h2>
                     <div class="flex items-center gap-2">
-                        <label for="ecm-year-filter" class="text-sm font-medium">Período:</label>
-                        <select id="ecm-year-filter" class="border-gray-300 rounded-md shadow-sm">${yearOptions}</select>
+                        <label for="dashboard-year-filter" class="text-sm font-medium">Período:</label>
+                        <select id="dashboard-year-filter" class="border-gray-300 rounded-md shadow-sm">${yearOptions}</select>
                     </div>
                 </div>
 
@@ -2023,17 +2017,38 @@ async function runIndicadoresEcrLogic() {
                     <div class="h-80 relative"><canvas id="eco-pie-chart"></canvas></div>
                 </section>
 
+                <!-- Obsoletos Section -->
+                <section class="bg-white p-6 rounded-xl shadow-lg">
+                    <h3 class="text-xl font-bold text-slate-800 mb-4">Análisis de Obsoletos Anual</h3>
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+                        <div>
+                            <table class="w-full text-sm">
+                                <thead class="text-xs text-gray-700 uppercase bg-gray-100">
+                                    <tr><th class="px-4 py-3 text-left">Indicador</th><th class="px-4 py-3 text-right">Valor</th></tr>
+                                </thead>
+                                <tbody>
+                                    <tr class="border-b"><td class="px-4 py-3 font-semibold">CANTIDAD ANUAL</td><td id="obsoletos-anual" class="px-4 py-3 text-right font-mono font-bold">0</td></tr>
+                                    <tr class="border-b"><td class="px-4 py-3">CANTIDAD SEMESTRE 1</td><td id="obsoletos-s1" class="px-4 py-3 text-right font-mono">0</td></tr>
+                                    <tr class="border-b"><td class="px-4 py-3">CANTIDAD SEMESTRE 2</td><td id="obsoletos-s2" class="px-4 py-3 text-right font-mono">0</td></tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <div class="h-64 relative"><canvas id="obsoletos-bar-chart"></canvas></div>
+                    </div>
+                </section>
+
                 <!-- Plan de Acción Section -->
                 <section class="bg-white p-6 rounded-xl shadow-lg">
                     <h3 class="text-xl font-bold text-slate-800 mb-4">Plan de Acción</h3>
                     <div class="overflow-x-auto">
                         <table class="w-full text-sm">
                             <thead class="text-xs text-gray-700 uppercase bg-gray-100">
-                                <tr><th class="px-4 py-3 text-left">Acción</th><th class="px-4 py-3 text-left">Responsable</th><th class="px-4 py-3 text-left">Plazo</th><th class="px-4 py-3 text-left">Realizado</th></tr>
+                                <tr><th class="px-4 py-3 text-left">Acción</th><th class="px-4 py-3 text-left">Responsable</th><th class="px-4 py-3 text-left">Plazo</th><th class="px-4 py-3 text-center">Realizado</th></tr>
                             </thead>
                             <tbody>
-                                <tr class="border-b"><td class="px-4 py-3">Definir plan de reducción de ECRs fuera de plazo</td><td class="px-4 py-3">Líder de Ingeniería</td><td class="px-4 py-3">30/12/${currentYear}</td><td class="px-4 py-3">No</td></tr>
-                                <tr class="border-b"><td class="px-4 py-3">Analizar causas de cancelación de ECRs</td><td class="px-4 py-3">Equipo de Calidad</td><td class="px-4 py-3">15/01/${currentYear + 1}</td><td class="px-4 py-3">No</td></tr>
+                                <tr class="border-b"><td class="px-4 py-3">Definir plan de reducción de ECRs fuera de plazo</td><td class="px-4 py-3">Líder de Ingeniería</td><td class="px-4 py-3">30/12/${currentYear}</td><td class="px-4 py-3 text-center"><span class="inline-block w-4 h-4 rounded-full bg-red-400"></span></td></tr>
+                                <tr class="border-b"><td class="px-4 py-3">Analizar causas de cancelación de ECRs</td><td class="px-4 py-3">Equipo de Calidad</td><td class="px-4 py-3">15/01/${currentYear + 1}</td><td class="px-4 py-3 text-center"><span class="inline-block w-4 h-4 rounded-full bg-red-400"></span></td></tr>
+                                <tr class="border-b"><td class="px-4 py-3">Revisar KPIs de ECOs con el equipo de Proceso</td><td class="px-4 py-3">Líder de Proceso</td><td class="px-4 py-3">28/12/${currentYear}</td><td class="px-4 py-3 text-center"><span class="inline-block w-4 h-4 rounded-full bg-green-400"></span></td></tr>
                             </tbody>
                         </table>
                     </div>
@@ -2043,24 +2058,30 @@ async function runIndicadoresEcrLogic() {
         dom.viewContent.innerHTML = viewHTML;
         lucide.createIcons();
 
-        const updateEcmDashboard = () => {
-            const yearFilter = document.getElementById('ecm-year-filter');
+        const updateDashboardData = () => {
+            const yearFilter = document.getElementById('dashboard-year-filter');
             if (!yearFilter || !appState.isAppInitialized) return;
             const selectedYear = parseInt(yearFilter.value, 10);
 
             // ECR Data
             const ecrDocs = appState.collections[COLLECTIONS.ECR_FORMS] || [];
             const filteredEcrs = ecrDocs.filter(ecr => ecr.fecha_emision && new Date(ecr.fecha_emision).getFullYear() === selectedYear);
+
             let ecrAbierta = 0, ecrCancelada = 0, ecrCerradaPlazo = 0, ecrCerradaFueraPlazo = 0;
             filteredEcrs.forEach(ecr => {
                 if (ecr.status === 'in-progress') ecrAbierta++;
                 else if (ecr.status === 'rejected') ecrCancelada++;
                 else if (ecr.status === 'approved') {
+                    // Check if fecha_emision and lastModified are valid
                     if (ecr.fecha_emision && ecr.lastModified?.toDate) {
-                        const fechaEmision = new Date(ecr.fecha_emision + "T00:00:00");
+                        const fechaEmision = new Date(ecr.fecha_emision + "T00:00:00"); // Ensure it's parsed correctly
                         const fechaCierre = ecr.lastModified.toDate();
                         const diffDays = (fechaCierre - fechaEmision) / (1000 * 60 * 60 * 24);
-                        diffDays <= 30 ? ecrCerradaPlazo++ : ecrCerradaFueraPlazo++;
+                        if(diffDays <= 30) {
+                            ecrCerradaPlazo++;
+                        } else {
+                            ecrCerradaFueraPlazo++;
+                        }
                     }
                 }
             });
@@ -2073,7 +2094,7 @@ async function runIndicadoresEcrLogic() {
             const ecrChartCtx = document.getElementById('ecr-doughnut-chart')?.getContext('2d');
             if (ecrChartCtx) {
                 if (ecrChart) ecrChart.destroy();
-                ecrChart = new Chart(ecrChartCtx, createDashboardChartConfig('doughnut', ["Abiertas", "Canceladas", "En Plazo", "Fuera de Plazo"], [ecrAbierta, ecrCancelada, ecrCerradaPlazo, ecrCerradaFueraPlazo], "Distribución de ECRs"));
+                ecrChart = new Chart(ecrChartCtx, createDashboardChartConfig('doughnut', ["Abiertas", "Canceladas", "En Plazo", "Fuera de Plazo"], [ecrAbierta, ecrCancelada, ecrCerradaPlazo, ecrCerradaFueraPlazo]));
             }
 
             // ECO Data
@@ -2082,6 +2103,7 @@ async function runIndicadoresEcrLogic() {
             const ecoPendiente = filteredEcos.filter(eco => eco.status === 'in-progress').length;
             const ecoApertura = filteredEcos.filter(eco => eco.status === 'approved').length;
             const ecoRechazada = filteredEcos.filter(eco => eco.status === 'rejected').length;
+
             document.getElementById('eco-kpi-cards').innerHTML =
                 createKpiCard("ECO Pendiente", ecoPendiente, 'hourglass', 'yellow') +
                 createKpiCard("ECO Apertura", ecoApertura, 'folder-check', 'green') +
@@ -2090,240 +2112,54 @@ async function runIndicadoresEcrLogic() {
             const ecoChartCtx = document.getElementById('eco-pie-chart')?.getContext('2d');
             if (ecoChartCtx) {
                 if (ecoChart) ecoChart.destroy();
-                ecoChart = new Chart(ecoChartCtx, createDashboardChartConfig('pie', ["Pendiente", "Apertura", "Rechazada"], [ecoPendiente, ecoApertura, ecoRechazada], "Distribución de ECOs"));
+                ecoChart = new Chart(ecoChartCtx, createDashboardChartConfig('pie', ["Pendiente", "Apertura", "Rechazada"], [ecoPendiente, ecoApertura, ecoRechazada]));
             }
-            lucide.createIcons();
-        };
 
-        document.getElementById('ecm-year-filter').addEventListener('change', updateEcmDashboard);
-        const unsub1 = onSnapshot(collection(db, COLLECTIONS.ECR_FORMS), updateEcmDashboard);
-        const unsub2 = onSnapshot(collection(db, COLLECTIONS.ECO_FORMS), updateEcmDashboard);
-        activeDashboardUnsub = () => { unsub1(); unsub2(); };
-        updateEcmDashboard();
-    };
+            // Obsoletos Data (dummy data as requested)
+            const s1 = 0;
+            const s2 = 0;
+            document.getElementById('obsoletos-anual').textContent = s1 + s2;
+            document.getElementById('obsoletos-s1').textContent = s1;
+            document.getElementById('obsoletos-s2').textContent = s2;
 
-    const renderObsoletosIndicatorView = () => {
-        cleanup();
-        dom.viewContent.innerHTML = `
-            <div class="animate-fade-in">
-                <button data-action="back-to-hub" class="mb-4 bg-slate-200 text-slate-700 px-4 py-2 rounded-md hover:bg-slate-300 text-sm font-semibold">&larr; Volver al Panel de Indicadores</button>
-                <h1 class="text-2xl font-bold">Indicador de Obsoletos</h1><p>Dashboard en construcción.</p>
-            </div>
-        `;
-        lucide.createIcons();
-    };
-
-    const renderHub = () => {
-        cleanup();
-        dom.viewContent.innerHTML = `
-            <div class="animate-fade-in-up">
-                <div class="text-center mb-12"><h2 class="text-4xl font-extrabold text-slate-800">Panel de Indicadores</h2><p class="text-lg text-slate-500 mt-2">Seleccione un dashboard para visualizar.</p></div>
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-8 max-w-4xl mx-auto">
-                    <div data-dashboard="ecm" class="dashboard-card bg-white rounded-xl shadow-lg hover:shadow-2xl transition-shadow duration-300 cursor-pointer overflow-hidden transform hover:-translate-y-2">
-                        <div class="p-6 bg-blue-600 text-white"><div class="flex items-center gap-4"><i data-lucide="layout-list" class="w-10 h-10"></i><div><h3 class="text-2xl font-bold">Indicador ECM</h3><p class="opacity-90">ECR / ECO</p></div></div></div>
-                        <div class="p-6"><p class="text-slate-600">Visualice el estado de los ECRs y el progreso de los ECOs.</p></div>
-                    </div>
-                    <div data-dashboard="obsoletos" class="dashboard-card bg-white rounded-xl shadow-lg hover:shadow-2xl transition-shadow duration-300 cursor-pointer overflow-hidden transform hover:-translate-y-2">
-                        <div class="p-6 bg-slate-700 text-white"><div class="flex items-center gap-4"><i data-lucide="archive-restore" class="w-10 h-10"></i><div><h3 class="text-2xl font-bold">Indicador de Obsoletos</h3><p class="opacity-90">Análisis Anual</p></div></div></div>
-                        <div class="p-6"><p class="text-slate-600">Analice la gestión de componentes obsoletos a nivel anual y semestral.</p></div>
-                    </div>
-                </div>
-            </div>`;
-        lucide.createIcons();
-    };
-
-    const handleNavigation = (e) => {
-        const card = e.target.closest('.dashboard-card');
-        if (card) {
-            const dashboardType = card.dataset.dashboard;
-            if (dashboardType === 'ecm') renderIndicadorEcmView();
-            else if (dashboardType === 'obsoletos') renderObsoletosIndicatorView();
-            return;
-        }
-        if (e.target.closest('button[data-action="back-to-hub"]')) {
-            renderHub();
-        }
-    };
-
-    dom.viewContent.addEventListener('click', handleNavigation);
-    renderHub();
-    appState.currentViewCleanup = () => {
-        dom.viewContent.removeEventListener('click', handleNavigation);
-        cleanup();
-    };
-}
-
-async function runControlEcrsLogic() {
-    dom.headerActions.style.display = 'none';
-    let allEcrs = []; // To store all ECRs for client-side filtering
-
-    const renderTableRows = (ecrsToRender) => {
-        const tableBody = dom.viewContent.querySelector('#ecr-control-table-body');
-        if (!tableBody) return;
-
-        if (ecrsToRender.length === 0) {
-            tableBody.innerHTML = `<tr><td colspan="20" class="text-center py-16 text-gray-500">No se encontraron ECRs que coincidan con la búsqueda.</td></tr>`;
-            return;
-        }
-
-        const statusPill = (status) => {
-            if (!status) return `<span class="status-pill bg-gray-200 text-gray-800">N/A</span>`;
-            const statusMap = {
-                'approved': { text: 'Aprobado', class: 'status-green' },
-                'in-progress': { text: 'En Progreso', class: 'status-yellow' },
-                'rejected': { text: 'Rechazado', class: 'status-red' }
-            };
-            const s = statusMap[status] || { text: status, class: 'bg-gray-200 text-gray-800' };
-            return `<span class="status-pill ${s.class}">${s.text}</span>`;
-        };
-
-        tableBody.innerHTML = ecrsToRender.map(ecr => {
-            const origem = ecr.origen_cliente ? 'Cliente' : (ecr.origen_interno ? 'Interno' : (ecr.origen_proveedor ? 'Proveedor' : (ecr.origen_reglamentacion ? 'Reglamentación' : 'N/A')));
-            const tipoEcr = ecr.tipo_producto ? 'Producto' : (ecr.tipo_proceso ? 'Proceso' : (ecr.tipo_otro ? ecr.tipo_otro_text || 'Otro' : 'N/A'));
-
-            // Asynchronously fetch related ECO status
-            const ecoStatusCellId = `eco-status-${ecr.id}`;
-            if (ecr.id) {
-                getDoc(doc(db, COLLECTIONS.ECO_FORMS, ecr.id)).then(ecoSnap => {
-                    const ecoStatus = ecoSnap.exists() ? ecoSnap.data().status : null;
-                    const cell = document.getElementById(ecoStatusCellId);
-                    if (cell) {
-                        cell.innerHTML = statusPill(ecoStatus);
+            const obsoletosChartCtx = document.getElementById('obsoletos-bar-chart')?.getContext('2d');
+            if (obsoletosChartCtx) {
+                 if (obsoletosChart) obsoletosChart.destroy();
+                 obsoletosChart = new Chart(obsoletosChartCtx, {
+                    type: 'bar',
+                    data: {
+                        labels: ['Semestre 1', 'Semestre 2'],
+                        datasets: [{
+                            label: 'Cantidad de Obsoletos',
+                            data: [s1, s2],
+                            backgroundColor: ['#60a5fa', '#3b82f6'],
+                            borderRadius: 4,
+                            maxBarThickness: 50
+                        }]
+                    },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        plugins: { legend: { display: false } },
+                        scales: { y: { beginAtZero: true, ticks: { precision: 0 } }, x: { grid: { display: false } } }
                     }
-                });
+                 });
             }
 
-            return `
-            <tr class="hover:bg-slate-50 transition-colors">
-                <td class="px-3 py-2">${ecr.id || 'N/A'}</td>
-                <td class="px-3 py-2">${ecr.cliente || 'N/A'}</td>
-                <td class="px-3 py-2">${'MAL'}</td>
-                <td class="px-3 py-2">${origem}</td>
-                <td class="px-3 py-2">${tipoEcr}</td>
-                <td class="px-3 py-2">${ecr.fecha_emision || 'N/A'}</td>
-                <td class="px-3 py-2">${ecr.denominacion_producto || 'N/A'}</td>
-                <td class="px-3 py-2">${ecr.codigo_barack || 'N/A'}</td>
-                <td class="px-3 py-2">${ecr.codigo_cliente || 'N/A'}</td>
-                <td class="px-3 py-2">${ecr.equipo_c1_0 || ecr.modifiedBy || 'N/A'}</td>
-                <td class="px-3 py-2">${ecr.fecha_cierre || 'N/A'}</td>
-                <td class="px-3 py-2">${ecr.fecha_realizacion_ecr || 'N/A'}</td>
-                <td class="px-3 py-2">${statusPill(ecr.status)}</td>
-                <td class="px-3 py-2" id="${ecoStatusCellId}">${statusPill(null)}</td>
-                <td class="px-3 py-2 whitespace-normal">${ecr.situacion_propuesta || 'N/A'}</td>
-                <td class="px-3 py-2">${ecr.causas_solicitud || 'N/A'}</td>
-                <td class="px-3 py-2">${ecr.comentarios_alertas || 'N/A'}</td>
-                <td class="px-3 py-2">${ecr.componentes_obsoletos || 'N/A'}</td>
-                <td class="px-3 py-2">${ecr.accion_objetiva || 'N/A'}</td>
-                <td class="px-3 py-2">${ecr.final_coordinador || 'N/A'}</td>
-            </tr>
-        `}).join('');
-    };
-
-    const filterAndRender = () => {
-        const searchTerm = dom.viewContent.querySelector('#ecr-control-search').value.toLowerCase();
-        if (!searchTerm) {
-            renderTableRows(allEcrs);
-            return;
-        }
-        const filtered = allEcrs.filter(ecr =>
-            Object.values(ecr).some(val =>
-                String(val).toLowerCase().includes(searchTerm)
-            )
-        );
-        renderTableRows(filtered);
-    };
-
-    const viewHTML = `
-    <div class="bg-white p-6 rounded-xl shadow-lg animate-fade-in-up">
-        <style>
-            .status-pill { display: inline-block; padding: 0.2rem 0.6rem; border-radius: 9999px; font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; }
-            .status-green { background-color: #d1fae5; color: #065f46; }
-            .status-yellow { background-color: #fef9c3; color: #854d0e; }
-            .status-red { background-color: #fee2e2; color: #991b1b; }
-            .corporate-header { background-color: #4A5568; color: white; }
-            .modern-table { border-collapse: collapse; width: 100%; font-size: 0.8rem; table-layout: fixed; min-width: 2400px;}
-            .modern-table th, .modern-table td { padding: 0.75rem; text-align: left; border-bottom: 1px solid #E2E8F0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-            .modern-table th { font-weight: bold; }
-            .modern-table th:nth-child(15), .modern-table td:nth-child(15) { width: 400px; white-space: normal; }
-            .modern-table th:nth-child(16), .modern-table td:nth-child(16) { width: 250px; white-space: normal; }
-            .modern-table th:nth-child(17), .modern-table td:nth-child(17) { width: 250px; white-space: normal; }
-            .modern-table th:nth-child(7), .modern-table td:nth-child(7) { width: 250px; white-space: normal; }
-        </style>
-        <header class="flex justify-between items-start mb-6">
-            <div class="flex items-center gap-4">
-                <img src="barack_logo.png" alt="Logo BARACK MERCOSUL" class="h-12 w-auto">
-                <div>
-                    <h1 class="text-2xl font-bold text-gray-800" style="font-family: 'Inter', sans-serif;">PANEL de control ECR</h1>
-                    <p class="text-gray-500 text-sm">Hoja de seguimiento de proyectos corporativa</p>
-                </div>
-            </div>
-            <div class="text-sm text-gray-600 text-right">
-                <div><strong>Fecha:</strong> ${new Date().toLocaleDateString('es-AR')}</div>
-                <div><strong>Responsable:</strong> ${appState.currentUser.name}</div>
-            </div>
-        </header>
-
-        <div class="mb-4">
-            <div class="relative">
-                <i data-lucide="search" class="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-slate-400"></i>
-                <input type="text" id="ecr-control-search" placeholder="Buscar en todos los campos..." class="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-full shadow-sm focus:ring-2 focus:ring-blue-500">
-            </div>
-        </div>
-
-        <div class="overflow-x-auto border border-slate-200 rounded-lg">
-            <table class="modern-table">
-                <thead class="corporate-header">
-                    <tr>
-                        <th>N° de ECR</th>
-                        <th>Cliente</th>
-                        <th>Site</th>
-                        <th>Origem del Pedido (Cliente ou interno)</th>
-                        <th>Tipo ECR</th>
-                        <th>Fecha de Abertura</th>
-                        <th>Producto Afectado</th>
-                        <th>Código Programa</th>
-                        <th>SIC</th>
-                        <th>Responsable</th>
-                        <th>Plazo ECR</th>
-                        <th>Fecha realizacion ECR</th>
-                        <th>Status ECR</th>
-                        <th>Status ECO</th>
-                        <th>Descripcion</th>
-                        <th>Causas Quien solicito el pedido</th>
-                        <th>Comentarios N°de Alert / Fete / concert</th>
-                        <th>Componente Obsoletos</th>
-                        <th>Accion Objetiva</th>
-                        <th>Responsable</th>
-                    </tr>
-                </thead>
-                <tbody id="ecr-control-table-body">
-                    <tr><td colspan="20" class="text-center py-16 text-gray-500"><i data-lucide="loader" class="animate-spin h-8 w-8 mx-auto"></i><p class="mt-2">Cargando datos...</p></td></tr>
-                </tbody>
-            </table>
-        </div>
-    </div>
-    `;
-    dom.viewContent.innerHTML = viewHTML;
-    lucide.createIcons();
-
-    dom.viewContent.querySelector('#ecr-control-search').addEventListener('input', filterAndRender);
-
-    const unsubscribe = onSnapshot(collection(db, COLLECTIONS.ECR_FORMS), (snapshot) => {
-        allEcrs = snapshot.docs.map(doc => doc.data());
-        filterAndRender(); // Render with current search term
-    }, (error) => {
-        console.error("Error fetching ECRs for control panel:", error);
-        showToast('Error al cargar los datos de ECR.', 'error');
-        const tableBody = dom.viewContent.querySelector('#ecr-control-table-body');
-        if (tableBody) {
-            tableBody.innerHTML = `<tr><td colspan="20" class="text-center py-16 text-red-500"><i data-lucide="alert-triangle" class="mx-auto h-8 w-8"></i><p class="mt-2">Error al cargar los datos.</p></td></tr>`;
             lucide.createIcons();
-        }
-    });
+        };
 
-    appState.currentViewCleanup = () => {
-        unsubscribe();
+        document.getElementById('dashboard-year-filter').addEventListener('change', updateDashboardData);
+
+        const unsub1 = onSnapshot(collection(db, COLLECTIONS.ECR_FORMS), updateDashboardData);
+        const unsub2 = onSnapshot(collection(db, COLLECTIONS.ECO_FORMS), updateDashboardData);
+        activeUnsubscribes.push(unsub1, unsub2);
+
+        updateDashboardData();
     };
+
+    renderDashboard();
+    appState.currentViewCleanup = cleanup;
 }
 
 async function runEcrFormLogic(params = null) {


### PR DESCRIPTION
Se rediseña por completo la sección 'PANEL de control' para unificar los indicadores de ECR y ECO en una única vista de dashboard funcional.

Cambios principales:
- Se unifica la navegación en `index.html`, eliminando enlaces duplicados y apuntando a una única vista `control_ecrs`.
- Se elimina la página intermedia de selección de indicadores.
- Se crea un nuevo dashboard unificado en `main.js` que incluye:
  - Análisis de ECR con 4 KPIs y gráfico de torta.
  - Análisis de ECO con 3 KPIs y gráfico de torta.
  - Sección de Análisis de Obsoletos con estructura visual y datos estáticos.
  - Tabla de Plan de Acción con datos de ejemplo.
- Se implementa un filtro de año global que controla todos los datos del dashboard.
- Los datos se actualizan en tiempo real mediante `onSnapshot` de Firestore.
- Se elimina el código obsoleto de las vistas `indicadores_ecr` y la antigua tabla de `control_ecrs`.