### PR TITLE
fix: Reincorporar acceso a gestión de ECO/ECR desde el panel

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -2003,6 +2003,26 @@ async function runControlEcrsLogic() {
                     </div>
                 </div>
 
+                <!-- Quick Actions Navigation -->
+                <section>
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                        <a href="#" data-view="ecr" class="nav-link dashboard-action-card bg-white rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-300 p-6 flex items-center gap-6 transform hover:-translate-y-1">
+                            <i data-lucide="file-plus-2" class="w-12 h-12 text-blue-600"></i>
+                            <div>
+                                <h4 class="text-xl font-bold text-slate-800">Gestionar ECRs</h4>
+                                <p class="text-slate-500">Ver, crear y editar Engineering Change Requests.</p>
+                            </div>
+                        </a>
+                        <a href="#" data-view="eco" class="nav-link dashboard-action-card bg-white rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-300 p-6 flex items-center gap-6 transform hover:-translate-y-1">
+                            <i data-lucide="recycle" class="w-12 h-12 text-green-600"></i>
+                            <div>
+                                <h4 class="text-xl font-bold text-slate-800">Gestionar ECOs</h4>
+                                <p class="text-slate-500">Ver, crear y editar Engineering Change Orders.</p>
+                            </div>
+                        </a>
+                    </div>
+                </section>
+
                 <!-- ECR Section -->
                 <section class="bg-white p-6 rounded-xl shadow-lg">
                     <h3 class="text-xl font-bold text-slate-800 mb-4">Análisis de ECR</h3>


### PR DESCRIPTION
Este commit corrige un error en la implementación anterior donde se eliminó el acceso a las vistas de gestión de ECO y ECR.

Se ha añadido una sección de "Acciones Rápidas" en la parte superior del nuevo Panel de Control unificado. Esta sección contiene enlaces claros y directos a las páginas "Gestionar ECRs" y "Gestionar ECOs".

Con este cambio, el Panel de Control funciona como el punto de entrada único que se solicitó, al mismo tiempo que sirve de hub para navegar a los submódulos de gestión, restaurando la funcionalidad perdida y cumpliendo con todos los requisitos del rediseño.