### PR TITLE
feat: Implement ECO/ECR Control Panel Hub and ECM Dashboard

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -144,13 +144,14 @@
                     <!-- Dropdown de ECO/ECR -->
                     <div class="relative nav-dropdown">
                         <button class="nav-link dropdown-toggle px-4 py-2 rounded-md text-sm font-medium text-slate-700 hover:bg-slate-100 flex items-center">
-                            <i data-lucide="layout-dashboard" class="inline-block w-4 h-4 mr-1.5 -mt-0.5"></i>ECO/ECR
+                            <i data-lucide="file-stack" class="inline-block w-4 h-4 mr-1.5 -mt-0.5"></i>ECO/ECR
                             <i data-lucide="chevron-down" class="w-4 h-4 ml-1"></i>
                         </button>
                         <div class="dropdown-menu absolute mt-2 w-72 bg-white border rounded-lg shadow-xl">
-                            <a href="#" data-view="control_ecrs" class="nav-link flex items-center gap-3 px-4 py-3 text-sm hover:bg-slate-100">
-                                <i data-lucide="layout-dashboard" class="w-5 h-5 text-slate-500"></i>Panel de Control
-                            </a>
+                            <a href="#" data-view="eco" class="nav-link flex items-center gap-3 px-4 py-3 text-sm hover:bg-slate-100"><i data-lucide="recycle" class="w-5 h-5 text-slate-500"></i>Gestión ECO</a>
+                            <a href="#" data-view="ecr" class="nav-link flex items-center gap-3 px-4 py-3 text-sm hover:bg-slate-100"><i data-lucide="file-plus-2" class="w-5 h-5 text-slate-500"></i>Gestión ECR</a>
+                            <div class="border-t my-1"></div>
+                            <a href="#" data-view="control_ecrs" class="nav-link flex items-center gap-3 px-4 py-3 text-sm hover:bg-slate-100"><i data-lucide="layout-dashboard" class="w-5 h-5 text-slate-500"></i>Panel de Control</a>
                         </div>
                     </div>
                     <!-- Dropdown de Gestión -->


### PR DESCRIPTION
This commit refactors the 'Panel de Control' section for ECO/ECR management.

Key changes:
- Creates a new hub page at 'Panel de Control' that provides navigation to two distinct sub-modules.
- Implements a new 'Indicadores ECM' dashboard with KPIs, charts, and sections for ECR, ECO, Obsoletos, and Plan de Acción analysis.
- The original large ECR tracking table is now accessible from the hub as 'Tabla de Control ECR'.
- Restores direct navigation to 'Gestión ECO' and 'Gestión ECR' from the main dropdown menu, as per user feedback.
- Refactors the global navigation logic in `main.js` to be more generic, allowing any element with a `data-view` attribute to trigger a view switch.