### PR TITLE
feat: Add missing 'componentes_obsoletos' field to ECR form

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -2513,6 +2513,13 @@ async function runEcrFormLogic(params = null) {
                 ${createTextField('Denominación del Producto:', 'denominacion_producto', '...', true)}
             </section>
 
+            <section class="form-row">
+                <div class="form-field">
+                    <label for="componentes_obsoletos" class="text-sm font-bold mb-1">Componentes Obsoletos (Cantidad):</label>
+                    <input type="number" name="componentes_obsoletos" id="componentes_obsoletos" placeholder="0" class="w-full" min="0">
+                </div>
+            </section>
+
             <div class="ecr-flex-section">
                 <div class="ecr-flex-header">OBJETIVO DE ECR</div>
                 <div class="ecr-flex-content ecr-flex-columns-2">


### PR DESCRIPTION
This change adds the 'Componentes Obsoletos' (Obsolete Components) input field to the ECR (Engineering Change Request) creation form.

The 'Indicadores ECM' (ECM Indicators) page was not displaying any data for the 'Análisis de Obsoletos Anual' (Annual Obsolescence Analysis) KPI. This was because the underlying calculation relied on the 'componentes_obsoletos' field from ECR documents in Firestore.

However, the ECR form itself was missing the input field for this value. As a result, any user-created ECR would have an undefined value for this field, causing the calculation to fail and the indicator to display '0'.

By adding the numeric input field to the form, users can now provide this essential data, which will allow the 'Indicadores ECM' page to calculate and display the KPI correctly, making the page functional as requested.