### PR TITLE
fix(ecm): Make Indicators Page Functional and Fix Loading Hang

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -233,7 +233,8 @@ let appState = {
         [COLLECTIONS.PRODUCTOS]: [], [COLLECTIONS.SEMITERMINADOS]: [], [COLLECTIONS.INSUMOS]: [], [COLLECTIONS.CLIENTES]: [],
         [COLLECTIONS.SECTORES]: [], [COLLECTIONS.PROCESOS]: [],
         [COLLECTIONS.PROVEEDORES]: [], [COLLECTIONS.UNIDADES]: [],
-        [COLLECTIONS.USUARIOS]: [], [COLLECTIONS.PROYECTOS]: [], [COLLECTIONS.ROLES]: [], [COLLECTIONS.TAREAS]: []
+        [COLLECTIONS.USUARIOS]: [], [COLLECTIONS.PROYECTOS]: [], [COLLECTIONS.ROLES]: [], [COLLECTIONS.TAREAS]: [],
+        [COLLECTIONS.ECR_FORMS]: [], [COLLECTIONS.ECO_FORMS]: []
     },
     collectionsById: {
         [COLLECTIONS.PRODUCTOS]: new Map(),
@@ -247,7 +248,9 @@ let appState = {
         [COLLECTIONS.USUARIOS]: new Map(),
         [COLLECTIONS.PROYECTOS]: new Map(),
         [COLLECTIONS.ROLES]: new Map(),
-        [COLLECTIONS.TAREAS]: new Map()
+        [COLLECTIONS.TAREAS]: new Map(),
+        [COLLECTIONS.ECR_FORMS]: new Map(),
+        [COLLECTIONS.ECO_FORMS]: new Map()
     },
     unsubscribeListeners: [],
     sinopticoState: null,


### PR DESCRIPTION
This commit resolves the issues preventing the "Indicadores ECM" page from displaying correctly and a subsequent bug that caused the application to hang on the loading screen.

The following fixes are included:

1.  **Added Missing 'componentes_obsoletos' Field to ECR Form:** The 'Análisis de Obsoletos Anual' KPI on the indicators page was always zero because the ECR creation form was missing an input for 'componentes_obsoletos'. This change adds the necessary numeric input field to the form, allowing this data to be captured.

2.  **Prioritized ECR/ECO Data Loading:** A race condition was discovered where the indicators page would attempt to render before its required data was loaded. This was fixed by adding `ECR_FORMS` and `ECO_FORMS` to the `essentialCollections` set in `startRealtimeListeners`, ensuring the data is available before the view is rendered.

3.  **Registered ECR/ECO Collections in App State:** A follow-up bug was introduced where the application would hang on the loading screen. This was because the `ECR_FORMS` and `ECO_FORMS` collections, while marked as essential, were not initialized in the `appState.collections` and `appState.collectionsById` objects. This commit adds them to the initial state, resolving the loading hang.

Together, these changes ensure that the necessary data can be entered, is loaded correctly, and is available for the "Indicadores ECM" page to be fully functional.