### PR TITLE
Fix Firestore permissions and improve ECR/ECM UI

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -19,8 +19,8 @@ service cloud.firestore {
 
     // --- USUARIOS ---
     match /usuarios/{userId} {
-      // Los admins pueden listar todos los usuarios.
-      allow list: if isUserAdmin();
+      // Cualquier usuario autenticado puede listar los usuarios para asignación de tareas.
+      allow list: if request.auth != null;
 
       // Un usuario puede leer su propio perfil. Los admins pueden leer todos.
       allow read: if request.auth.uid == userId || isUserAdmin();
@@ -88,6 +88,11 @@ service cloud.firestore {
       allow read: if request.auth != null;
       allow create, update: if canCreateUpdate();
       allow delete: if isUserAdmin();
+    }
+
+    match /action_plans/{planId} {
+      allow read: if request.auth != null;
+      allow create, update, delete: if canCreateUpdate();
     }
 
     match /eco_forms/{ecoId} {


### PR DESCRIPTION
This commit addresses several issues reported by the user regarding the ECR/ECM sections of the application.

Fixes:
- Adds a security rule for the `action_plans` collection in `firestore.rules` to resolve 'permission-denied' errors when adding a new action in the ECM Indicators view.
- Modifies the `list` rule for the `usuarios` collection to allow all authenticated users to read the user list, fixing a snapshot listener error for non-admin users and enabling task assignment functionality.
- Adjusts the `tareas` collection query to use client-side filtering for non-admins, preventing permission errors caused by queries that don't match security rules.
- Adjusts the `action_plans` query to filter by year on the client, avoiding the need for a Firestore index.

UI Improvements:
- Adds a 'Back' button to the "Tabla de Control ECR" view for consistent navigation.
- Adds a helper text hint to the "Tabla de Control ECR" to inform users that the wide table is horizontally scrollable.