### PR TITLE
Center content in ECR control table

### DIFF
--- a/public/ecr_table.css
+++ b/public/ecr_table.css
@@ -23,7 +23,7 @@
 .modern-table th,
 .modern-table td {
     padding: 0.75rem;
-    text-align: left;
+    text-align: center;
     border-bottom: 1px solid #e2e8f0;
     white-space: nowrap;
     vertical-align: middle;


### PR DESCRIPTION
This commit centers the text for both the headers and the cells in the ECR control table by changing the `text-align` property from `left` to `center` in the `ecr_table.css` file. This improves the visual organization of the table as requested.