### PR TITLE
fix(eco): Remove incorrect cleanup logic causing ReferenceError

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -1853,10 +1853,6 @@ async function runEcoLogic() {
 
     appState.currentViewCleanup = () => {
         unsubscribe();
-        slider.removeEventListener('mousedown', mouseDownHandler);
-        slider.removeEventListener('mouseleave', mouseLeaveHandler);
-        slider.removeEventListener('mouseup', mouseUpHandler);
-        slider.removeEventListener('mousemove', mouseMoveHandler);
     };
 }
 


### PR DESCRIPTION
Removes erroneous event listener cleanup code from the `runEcoLogic` function.

When navigating away from the 'Gestión de ECO' view, the application would crash with a `ReferenceError: slider is not defined`. This was caused by the view's cleanup function (`appState.currentViewCleanup`) attempting to remove event listeners from a `slider` variable.

This `slider` variable and its associated event listeners were never defined or used within the `runEcoLogic` view; the code appears to have been a copy-paste artifact from a different view that does use a slider component.

By removing these incorrect lines, the crash is prevented, and since the component was never created in this view, there is no risk of memory leaks from dangling event listeners.