### PR TITLE
feat: Crear submódulo de seguimiento y métricas de ECR

### DIFF
--- a/public/ecr_seguimiento.css
+++ b/public/ecr_seguimiento.css
@@ -1,0 +1,120 @@
+.ecr-log-table-wrapper {
+    border: 1px solid #e2e8f0;
+    border-radius: 0.5rem;
+    overflow: hidden;
+}
+
+.ecr-log-table th, .ecr-log-table td {
+    padding: 0.5rem;
+    border-right: 1px solid #e2e8f0;
+    border-bottom: 1px dotted #cbd5e1;
+    white-space: nowrap;
+    text-align: left;
+}
+
+.ecr-log-table thead th {
+    font-weight: 600;
+    font-size: 0.75rem;
+    letter-spacing: 0.05em;
+    vertical-align: bottom;
+}
+
+.ecr-log-table thead th[style*="vertical-rl"] {
+    padding: 8px 4px;
+    height: 150px;
+    white-space: nowrap;
+    text-align: center;
+}
+
+
+.ecr-log-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.ecr-log-table td:last-child, .ecr-log-table th:last-child {
+    border-right: none;
+}
+
+.status-ok {
+    background-color: #dff0d8 !important;
+    color: #3c763d !important;
+}
+
+.status-nok {
+    background-color: #f2dede !important;
+    color: #a94442 !important;
+}
+
+.atraso-bajo {
+    background-color: #dff0d8;
+    color: #3c763d;
+}
+.atraso-medio {
+    background-color: #fcf8e3;
+    color: #8a6d3b;
+}
+.atraso-alto {
+    background-color: #f2dede;
+    color: #a94442;
+}
+
+/* --- Matriz de Asistencia --- */
+.asistencia-matriz-wrapper {
+    border: 1px solid #e2e8f0;
+    border-radius: 0.5rem;
+    overflow: hidden;
+}
+
+.asistencia-matriz-table th, .asistencia-matriz-table td {
+    padding: 0.75rem;
+    border-right: 1px solid #e2e8f0;
+    border-bottom: 1px solid #e2e8f0;
+    white-space: nowrap;
+    text-align: center;
+}
+
+.asistencia-matriz-table .sticky {
+    position: sticky;
+    left: 0;
+    border-right: 2px solid #94a3b8;
+}
+
+.asistencia-matriz-table td.sticky {
+    text-align: left;
+}
+
+.status-p {
+    background-color: #dff0d8 !important;
+    color: #3c763d !important;
+}
+
+.status-a {
+    background-color: #f2dede !important;
+    color: #a94442 !important;
+}
+
+.status-o {
+    background-color: #f5f5f5 !important;
+    color: #777 !important;
+}
+
+/* --- Resumen Table --- */
+.resumen-table-wrapper {
+    border: 1px solid #e2e8f0;
+    border-radius: 0.5rem;
+    overflow: hidden;
+}
+.resumen-table th, .resumen-table td {
+    padding: 0.75rem;
+    border-bottom: 1px solid #e2e8f0;
+    text-align: center;
+}
+.resumen-table td:first-child {
+    text-align: left;
+}
+.resumen-table thead th {
+    font-weight: 600;
+}
+.resumen-table tbody tr:last-child td {
+    border-bottom: none;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -22,6 +22,7 @@
     <link rel="stylesheet" href="eco_form.css">
     <link rel="stylesheet" href="ecr_form.css">
     <link rel="stylesheet" href="ecr_table.css">
+    <link rel="stylesheet" href="ecr_seguimiento.css">
 </head>
 <body class="bg-white">
 

--- a/public/utils.js
+++ b/public/utils.js
@@ -13,7 +13,8 @@ export const COLLECTIONS = {
     ROLES: 'roles',
     ECO_FORMS: 'eco_forms',
     ECR_FORMS: 'ecr_forms',
-    COVER_MASTER: 'cover_master'
+    COVER_MASTER: 'cover_master',
+    REUNIONES_ECR: 'reuniones_ecr'
 };
 
 export function getUniqueKeyForCollection(collectionName) {


### PR DESCRIPTION
Se añade un nuevo submódulo accesible desde el Panel de Control para el seguimiento de ECR y reuniones asociadas.

Esta nueva vista consolidada, 'Seguimiento y Métricas de ECR', incluye tres componentes principales:

1.  **Registro de ECR**: Una tabla que muestra el historial de ECRs, calculando automáticamente el retraso en días y mostrando el estado de revisión de cada departamento (OK/NOK) con formato condicional.

2.  **Matriz de Asistencia**: Una tabla que muestra la asistencia (Presente, Ausente, Opcional) de cada departamento a las reuniones de ECR. Para esto, se ha creado una nueva colección en Firestore, `reuniones_ecr`, y se han añadido datos de ejemplo.

3.  **Resumen y Gráficos**: Una tabla de resumen con estadísticas de ausentismo por departamento y dos gráficos de barras que visualizan los días de ausencia y el porcentaje total de ausentismo.

Se ha añadido la configuración necesaria para la nueva vista, su ruta, y los estilos CSS correspondientes para asegurar una correcta integración visual y funcional con el resto de la aplicación.