### PR TITLE
fix: Añadir reglas de seguridad para la colección reuniones_ecr

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -121,6 +121,12 @@ service cloud.firestore {
       }
     }
 
+    match /reuniones_ecr/{reunionId} {
+      allow read: if request.auth != null;
+      allow create, update: if canCreateUpdate();
+      allow delete: if isUserAdmin();
+    }
+
     // --- CARÁTULA MAESTRA ---
     match /cover_master/{docId} {
       // Anyone authenticated can read the master cover.


### PR DESCRIPTION
Se añaden las reglas de seguridad necesarias en `firestore.rules` para la nueva colección `reuniones_ecr`.

Este cambio soluciona un error de 'permisos insuficientes' que impedía que la aplicación se cargara correctamente después de la implementación de la nueva funcionalidad de seguimiento de ECR.