### PR TITLE
fix: Make ECR tracking view reactive to data changes

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -374,6 +374,9 @@ function startRealtimeListeners() {
                     if (viewConfig[appState.currentView]?.dataKey === name) {
                         runTableLogic();
                     }
+                    if (appState.currentView === 'ecr_seguimiento' && (name === COLLECTIONS.REUNIONES_ECR || name === COLLECTIONS.ECR_FORMS)) {
+                        runEcrSeguimientoLogic();
+                    }
                 }
 
             }, (error) => {


### PR DESCRIPTION
Modifies the global 'onSnapshot' listener to re-render the 'ecr_seguimiento' view when its underlying data (reuniones or ECR forms) is updated.

This resolves an issue where adding a new meeting or changing a status did not update the UI, making the view feel static.