### PR TITLE
Fix(ecr-seguimiento): Prevent buttons from becoming blank

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -2889,13 +2889,13 @@ async function runEcrSeguimientoLogic() {
             const data = docSnap.data();
             const updateData = {};
 
-            if (data[okKey]) { // Current state is OK
+            if (data[okKey]) { // Current state is OK -> change to NOK
                 updateData[okKey] = false;
                 updateData[nokKey] = true;
-            } else if (data[nokKey]) { // Current state is NOK
-                updateData[okKey] = false;
+            } else if (data[nokKey]) { // Current state is NOK -> change to OK
+                updateData[okKey] = true;
                 updateData[nokKey] = false;
-            } else { // Current state is empty
+            } else { // Current state is empty -> change to OK
                 updateData[okKey] = true;
                 updateData[nokKey] = false;
             }
@@ -2971,7 +2971,7 @@ async function runEcrSeguimientoLogic() {
 
             if (!reunionId || !deptoId) return;
 
-            const statusCycle = { '': 'P', 'P': 'A', 'A': 'O', 'O': '' };
+            const statusCycle = { '': 'P', 'P': 'A', 'A': 'O', 'O': 'P' };
             const currentStatus = button.textContent;
             const nextStatus = statusCycle[currentStatus];
 


### PR DESCRIPTION
The state-cycling logic for the OK/NOK and Presente/Ausente/Opcional buttons in the 'Seguimiento y Métricas de ECR' view has been adjusted.

Previously, the buttons would cycle through their states and then return to an empty/blank state, which was confusing for the user as it appeared the state was lost.

This commit modifies the logic so that the buttons now loop through their active states without becoming blank, providing a more intuitive and predictable user experience.

- OK/NOK buttons now cycle between 'OK' and 'NOK'.
- Asistencia buttons now cycle between 'P', 'A', and 'O'.