### PR TITLE
fix(firebase): Add missing NOTIFICATIONS constant

### DIFF
--- a/public/utils.js
+++ b/public/utils.js
@@ -14,7 +14,8 @@ export const COLLECTIONS = {
     ECO_FORMS: 'eco_forms',
     ECR_FORMS: 'ecr_forms',
     COVER_MASTER: 'cover_master',
-    REUNIONES_ECR: 'reuniones_ecr'
+    REUNIONES_ECR: 'reuniones_ecr',
+    NOTIFICATIONS: 'notifications'
 };
 
 export function getUniqueKeyForCollection(collectionName) {


### PR DESCRIPTION
Resolves a 'Missing or insufficient permissions' error that occurred on startup.

The error was caused by `main.js` attempting to create a Firestore listener for `COLLECTIONS.NOTIFICATIONS`. However, the `NOTIFICATIONS` key was not defined in the `COLLECTIONS` object in `utils.js`.

This resulted in an attempt to listen to a collection with the name 'undefined', which triggered the Firebase permission error. This patch adds the missing constant to `utils.js` to resolve the issue.