### PR TITLE
fix(firebase): Add notifications collection rule and constant

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -206,5 +206,14 @@ service cloud.firestore {
       allow delete: if request.auth != null &&
                       (isUserAdmin() || resource.data.creatorUid == request.auth.uid);
     }
+
+    // --- NOTIFICACIONES ---
+    match /notifications/{notificationId} {
+      // Un usuario puede leer, actualizar o eliminar sus propias notificaciones.
+      allow read, update, delete: if request.auth != null && request.auth.uid == resource.data.userId;
+
+      // Cualquier usuario autenticado puede crear una notificación (la lógica de la app determina para quién es).
+      allow create: if request.auth != null;
+    }
   }
 }


### PR DESCRIPTION
This commit resolves the 'Missing or insufficient permissions' error related to the 'notifications' collection.

The fix is two-fold:
1.  Adds the `NOTIFICATIONS: 'notifications'` constant to the `COLLECTIONS` object in `public/utils.js`. This resolves an initial error where the app tried to listen to an 'undefined' collection.
2.  Adds a new security rule to `firestore.rules` for the `notifications` collection. This rule allows users to read/write their own notifications, which resolves the subsequent permission error.