### PR TITLE
fix: Revert tutorial highlight and fix pointer events

### DIFF
--- a/public/tutorial.css
+++ b/public/tutorial.css
@@ -9,25 +9,17 @@
     left: 0;
     width: 100vw;
     height: 100vh;
-    background-color: rgba(0, 0, 0, 0.5);
     z-index: 10000;
     display: none;
+    pointer-events: none; /* Allow clicks to pass through the overlay */
 }
 
 /* Element to highlight the focused part of the UI */
-#tutorial-overlay {
-    /* ... existing styles ... */
-    /* This will be controlled by JS now */
-    clip-path: polygon(0% 0%, 0% 100%, 100% 100%, 100% 0%);
-    transition: clip-path 0.3s ease-in-out;
-}
-
 #tutorial-highlight {
     position: absolute;
-    border: 2px dashed rgba(255, 255, 255, 0.7);
     border-radius: 8px;
+    box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.6);
     transition: all 0.3s ease-in-out;
-    pointer-events: none;
 }
 
 /* Tooltip container */
@@ -43,6 +35,7 @@
     font-family: 'Inter', sans-serif;
     display: flex;
     flex-direction: column;
+    pointer-events: auto; /* But allow interaction with the tooltip */
 }
 
 /* Main content area of the tooltip */

--- a/public/tutorial.js
+++ b/public/tutorial.js
@@ -103,26 +103,11 @@ const tutorial = (app) => {
         const targetRect = targetElement.getBoundingClientRect();
         const padding = 5;
 
-        // Position the dashed border highlight
+        // Position the highlight
         dom.highlight.style.width = `${targetRect.width + (padding * 2)}px`;
         dom.highlight.style.height = `${targetRect.height + (padding * 2)}px`;
         dom.highlight.style.top = `${targetRect.top - padding}px`;
         dom.highlight.style.left = `${targetRect.left - padding}px`;
-
-        // Create the "hole" in the overlay using clip-path
-        const top = targetRect.top - padding;
-        const left = targetRect.left - padding;
-        const bottom = targetRect.bottom + padding;
-        const right = targetRect.right + padding;
-
-        dom.overlay.style.clipPath = `polygon(
-            0% 0%, 0% 100%, 100% 100%, 100% 0%, 0% 0%,
-            ${left}px ${top}px,
-            ${left}px ${bottom}px,
-            ${right}px ${bottom}px,
-            ${right}px ${top}px,
-            ${left}px ${top}px
-        )`;
 
         positionTooltip(targetRect, step.position);
     };


### PR DESCRIPTION
This commit reverts the tutorial's highlighting mechanism to the visually preferred `box-shadow` method and resolves the click-interception issue that was affecting automated tests.

- Reverts the `clip-path` implementation in favor of the original `box-shadow` effect for highlighting tutorial steps, addressing user feedback about a visual regression.
- Fixes the click-interception problem by applying `pointer-events: none` to the tutorial overlay and `pointer-events: auto` to the tooltip. This allows clicks to pass through to the underlying UI elements while keeping the tooltip interactive.
- This approach provides the best of both worlds: the desired visual effect for the user and a robust, testable implementation for automation.
- Also includes the previous fixes for button placement, tooltip alignment, automatic scrolling, and visual click simulation.