### PR TITLE
feat(tutorial): Make tutorial more robust to race conditions

### DIFF
--- a/public/tutorial.css
+++ b/public/tutorial.css
@@ -153,3 +153,22 @@
     animation: tutorial-click-animation 1s ease-out;
     border-radius: 6px; /* Match highlight radius */
 }
+
+/* Style for when the tutorial is waiting for an element */
+#tutorial-tooltip.is-waiting {
+    animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+#tutorial-tooltip.is-waiting #tutorial-tooltip-nav,
+#tutorial-tooltip.is-waiting #tutorial-tooltip-progress {
+    visibility: hidden;
+}
+
+@keyframes pulse {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: .8;
+  }
+}


### PR DESCRIPTION
The interactive tutorial would sometimes fail to highlight elements because it would time out before the application had finished rendering the view, especially after asynchronous operations like view switching.

This change improves the tutorial's resilience and user experience in several ways:

- **Increased Timeout:** The timeout in `waitForVisibleElement` has been increased from 3 to 7 seconds, giving the application more time to render complex views.

- **Improved User Feedback:**
  - When waiting for an element to appear, the tooltip now displays a "Buscando Elemento..." message with a subtle pulsing animation.
  - If an element is not found after the timeout, the tooltip now explicitly shows an "Elemento no encontrado" message before skipping to the next step, rather than failing silently.

- **Refactored Logic:** The `showStep` and `waitForVisibleElement` functions were refactored to support this new feedback mechanism, making the tutorial flow smoother and more transparent for the user.