### PR TITLE
feat: Expand interactive tutorial to full ECR/ECO flow

### DIFF
--- a/public/tutorial.js
+++ b/public/tutorial.js
@@ -122,23 +122,16 @@ const tutorial = (app) => {
             content: 'Para este ECR aprobado de ejemplo, el botón "Generar ECO" está activo. Al hacer clic, se crea la Orden de Cambio de Ingeniería (ECO) y nos lleva a su formulario.',
             position: 'left',
             preAction: async () => {
+                // Ensure the view is correct before running the action.
                 await app.switchView('ecr');
-                // Ensure there's an approved ECR for the tutorial.
-                // This might involve creating a dummy one if none exist.
-                const approvedEcrRow = document.querySelector('tr:has(button[data-action="generate-eco-from-ecr"])');
-                if (!approvedEcrRow) {
-                    app.showToast("Creando ECR aprobado de ejemplo para el tutorial...", "info");
-                    const ecrId = `ECR-TUTORIAL-${Date.now()}`;
-                    const ecrData = {
-                        id: ecrId,
-                        status: 'approved',
-                        lastModified: new Date(),
-                        modifiedBy: 'Tutorial',
-                        descripcion: 'ECR de ejemplo para el tutorial'
-                    };
-                    await app.db.collection('ecr_forms').doc(ecrId).set(ecrData);
-                    // The view will update automatically via the listener.
-                }
+
+                // This helper function, exposed from main.js, now contains all the logic
+                // to create a sample approved ECR if one doesn't exist. This fixes the
+                // previous bug caused by incorrect Firestore v9 syntax here.
+                await app.createTutorialEcr();
+
+                // Small delay to ensure the UI updates if a new ECR was created by the helper.
+                await new Promise(resolve => setTimeout(resolve, 500));
             },
             click: true,
             postAction: async () => {


### PR DESCRIPTION
This commit expands the interactive tutorial to cover the entire Engineering Change Request (ECR) to Engineering Change Order (ECO) workflow.

Previously, the tutorial stopped after explaining the ECR approval process. This change adds the following steps:
- Guides the user to click the "Generate ECO" button on an approved ECR.
- Explains the purpose of the ECO form.
- Details the "Action Plan" section of the ECO.
- Interactively demonstrates how to add a new task to the action plan.
- Explains the concept of ECO closure.

This change also fixes a critical bug where the tutorial would stall because it couldn't find an approved ECR. A new helper function, `createTutorialEcr`, has been added to `main.js` to programmatically create a sample approved ECR, ensuring the tutorial can always proceed. The tutorial script (`tutorial.js`) has been updated to use this robust helper function instead of containing its own broken Firestore logic.