### PR TITLE
fix: Stabilize tutorial ECR creation step

### DIFF
--- a/public/tutorial.js
+++ b/public/tutorial.js
@@ -122,16 +122,12 @@ const tutorial = (app) => {
             content: 'Para este ECR aprobado de ejemplo, el botón "Generar ECO" está activo. Al hacer clic, se crea la Orden de Cambio de Ingeniería (ECO) y nos lleva a su formulario.',
             position: 'left',
             preAction: async () => {
-                // Ensure the view is correct before running the action.
-                await app.switchView('ecr');
-
-                // This helper function, exposed from main.js, now contains all the logic
-                // to create a sample approved ECR if one doesn't exist. This fixes the
-                // previous bug caused by incorrect Firestore v9 syntax here.
+                // The user is already on the 'ecr' view. Calling the helper directly
+                // is more stable and avoids potential race conditions with view re-initialization.
                 await app.createTutorialEcr();
 
-                // Small delay to ensure the UI updates if a new ECR was created by the helper.
-                await new Promise(resolve => setTimeout(resolve, 500));
+                // A slightly longer, more robust wait for the onSnapshot listener to fire and the UI to re-render.
+                await new Promise(resolve => setTimeout(resolve, 750));
             },
             click: true,
             postAction: async () => {


### PR DESCRIPTION
This commit fixes a persistent race condition in the interactive tutorial that caused it to stall when preparing the 'Generate ECO' step.

The previous fix correctly moved the ECR creation logic to a helper function, but the `preAction` in the tutorial script still contained a redundant `switchView` call. This could cause the view's data listener to be re-initialized at an unpredictable time, leading to the UI not updating before the tutorial looked for the target element.

The fix involves:
- Removing the unnecessary `switchView('ecr')` call from the `preAction`.
- Relying on the existing view and its data listener to update the UI upon the creation of the tutorial ECR document.
- Slightly increasing the post-action delay to make the wait for UI re-rendering more robust.