### PR TITLE
fix(tutorial): Programmatically click 'Generate ECO' button

### DIFF
--- a/public/tutorial.js
+++ b/public/tutorial.js
@@ -131,8 +131,12 @@ const tutorial = (app) => {
             },
             click: true,
             postAction: async () => {
-                // The click action in main.js handles the view switch.
-                // We just need to wait for the form to be visible.
+                // Find the button and click it to trigger the view switch.
+                const button = document.querySelector('button[data-action="generate-eco-from-ecr"]');
+                if (button) {
+                    button.click();
+                }
+                // Now, wait for the form to be visible as a result of the click.
                 await waitForVisibleElement('#eco-form');
             }
         },


### PR DESCRIPTION
The tutorial was failing when transitioning from the ECR view to the ECO form. The step's `postAction` was waiting for the ECO form to be visible without ever triggering the click that would make it appear.

This change modifies the `postAction` to explicitly find the 'Generate ECO' button and dispatch a click event on it before waiting for the form to render. This ensures the navigation is triggered correctly and allows the tutorial to proceed.