### PR TITLE
fix(tutorial): Programmatically click buttons to fix hangs

### DIFF
--- a/public/tutorial.js
+++ b/public/tutorial.js
@@ -200,6 +200,10 @@ const tutorial = (app) => {
             position: 'left',
             click: true,
             postAction: async () => {
+                const button = document.querySelector('[data-tutorial-id="add-action-item-btn"]');
+                if (button) {
+                    button.click();
+                }
                 await waitForVisibleElement('.action-item');
             }
         },


### PR DESCRIPTION
The tutorial was hanging or appearing very slow at two steps:
1. When navigating from the ECR list to the ECO form.
2. When adding an action item to the ECO plan.

The root cause for both issues was the same: the tutorial was waiting for an element to appear that would only be created after a button click, but the button was not being programmatically clicked. The `click: true` property was only adding a visual effect.

This change modifies the `postAction` for both tutorial steps to explicitly find the correct button and dispatch a `click()` event on it before waiting for the resulting element. This ensures the tutorial proceeds smoothly and instantly.