### PR TITLE
feat: Overhaul Seguimiento view and fix Control Panel tutorial

### DIFF
--- a/public/control-panel-tutorial.js
+++ b/public/control-panel-tutorial.js
@@ -224,7 +224,7 @@ const controlPanelTutorial = (app) => {
 
         if (dom.tooltip) dom.tooltip.classList.remove('is-waiting');
 
-        smartScroll(targetElement);
+        await smartScroll(targetElement);
 
         setTimeout(() => {
             document.getElementById('tutorial-tooltip-title').textContent = step.title;
@@ -244,7 +244,7 @@ const controlPanelTutorial = (app) => {
         }, 0);
     };
 
-    const smartScroll = (element) => {
+    const smartScroll = async (element) => {
         const rect = element.getBoundingClientRect();
         const isVisible = (
             rect.top >= 0 &&
@@ -254,7 +254,9 @@ const controlPanelTutorial = (app) => {
         );
 
         if (!isVisible) {
-            element.scrollIntoView({ behavior: 'instant', block: 'center' });
+            element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            // Wait for smooth scroll to finish. This is a trade-off for better UX.
+            await new Promise(resolve => setTimeout(resolve, 500));
         }
     };
 


### PR DESCRIPTION
This commit completely revamps the 'Seguimiento y Métricas' view and the associated Control Panel tutorial based on user feedback.

The 'Seguimiento y Métricas' view (`ecr_seguimiento`) is now a functional and interactive dashboard:
- The ECR Log now features clickable status indicators that open an approval modal.
- Authorized users (admins or department members) can now approve, reject, or set to pending the status of a department's review for an ECR, and add comments.
- The view now uses loading placeholders and provides clear empty states if no data is available, significantly improving the user experience.

The Control Panel tutorial (`control-panel-tutorial.js`) has been fixed and improved:
- Re-enabled smooth scrolling (`behavior: 'smooth'`) for a better user experience, as requested.
- Added a delay after scrolling to prevent race conditions, ensuring the tutorial remains stable.
- The `showStep` function is now correctly `async` and awaits the `smartScroll` function.