### PR TITLE
Fix(ecr, meetings): Correct two bugs in ECR module

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -3645,7 +3645,7 @@ async function runEcrSeguimientoLogic() {
 
             if (!reunionId || !deptoId) return;
 
-            const statusCycle = { '': 'P', 'P': 'A', 'A': 'O', 'O': 'P' };
+            const statusCycle = { '': 'P', 'P': 'A', 'A': 'O', 'O': '' };
             const currentStatus = button.textContent;
             const nextStatus = statusCycle[currentStatus];
 
@@ -7659,6 +7659,12 @@ async function registerEcrApproval(ecrId, departmentId, decision, comment) {
             }
 
             let ecrData = ecrDoc.data();
+
+            // FIX: Ensure approvals map exists to prevent crash on new ECRs
+            if (!ecrData.approvals) {
+                ecrData.approvals = {};
+            }
+
             const currentUserSector = appState.currentUser.sector;
 
             // Security Check: Ensure the user belongs to the department they are approving for.


### PR DESCRIPTION
This commit addresses two separate issues:

1.  **ECR Approval TypeError:** Fixes a `TypeError: Cannot set properties of undefined` that occurred when a user tried to approve a department on a newly created ECR. The `registerEcrApproval` function now defensively checks if the `approvals` map exists on the ECR document and initializes it if it doesn't. This makes the approval process robust for both new and existing ECRs.

2.  **Meeting Attendance Cycle:** Fixes an issue in the "Matriz de Asistencia a Reuniones" where users could not clear an attendance status once set. The status cycle has been changed from `'' -> P -> A -> O -> P` to `'' -> P -> A -> O -> ''`, allowing users to correctly cycle back to an empty state.