### PR TITLE
Refactor the ECR approval workflow to enforce the formal process.

### DIFF
--- a/public/ecr_form.css
+++ b/public/ecr_form.css
@@ -293,3 +293,12 @@
     font-size: 0.75rem; /* text-xs */
     margin-top: 0.25rem;
 }
+
+.highlight-section {
+  animation: highlight-animation 2.5s ease-out;
+}
+
+@keyframes highlight-animation {
+  0% { background-color: rgba(59, 130, 246, 0.25); }
+  100% { background-color: transparent; }
+}


### PR DESCRIPTION
This commit changes the behavior of the 'Summary ECR Log' (Registro de ECR). Previously, users could modify approval statuses via a modal directly from the summary table. This change removes that functionality.

The new workflow is as follows:
- Clicking any status cell in the 'Registro de ECR' now navigates the user to the detailed ECR form.
- If the ECR is pending approval from the user's department, the user is automatically scrolled to the relevant approval section within the detailed form. A temporary highlight is applied to this section for better visibility.
- If the ECR is not pending the user's approval, they are navigated to a read-only view of the detailed form.

This change ensures that all ECR approvals are made through the official 'Detailed ECR Form', maintaining a single point of entry and adhering to the documented approval process.