### PR TITLE
Refactor showToast to use template and fix Jest config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,4 +3,5 @@ export default {
     '^https://www.gstatic.com/firebasejs/9.15.0/firebase-firestore.js$': '<rootDir>/__mocks__/firebase-firestore.js',
   },
   testEnvironment: 'node',
+  testPathIgnorePatterns: ['/node_modules/', '/tests/'],
 };

--- a/public/main.js
+++ b/public/main.js
@@ -4822,7 +4822,11 @@ function showToast(message, type = 'success', duration = 3000) {
     const icons = { success: 'check-circle', error: 'alert-circle', info: 'info' };
     const toast = document.createElement('div');
     toast.className = `toast ${type}`;
-    toast.innerHTML = `<i data-lucide="${icons[type]}"></i><span>${message}</span>`;
+
+    const template = document.createElement('template');
+    template.innerHTML = `<i data-lucide="${icons[type]}"></i><span>${message}</span>`;
+    toast.appendChild(template.content.cloneNode(true));
+
     dom.toastContainer.appendChild(toast);
     lucide.createIcons();
     setTimeout(() => toast.classList.add('show'), 10);


### PR DESCRIPTION
This commit includes two improvements:

1.  The `showToast` function in `public/main.js` has been refactored to use the `document.createElement('template')` pattern. This is a security and performance best practice recommended in the project's AGENTS.md file, as it avoids direct `innerHTML` assignment.

2.  The `jest.config.js` file has been updated to ignore the `/tests/` directory. This is a necessary fix for the test runner. The `npm test` command was failing because Jest was incorrectly trying to execute Playwright end-to-end tests, which reside in `/tests/`. This change ensures `npm test` only runs the Jest unit tests located in the `public/` directory, allowing the command to pass as intended.