### PR TITLE
Fix: Correct control panel tutorial step order

### DIFF
--- a/public/new-control-panel-tutorial.js
+++ b/public/new-control-panel-tutorial.js
@@ -65,23 +65,9 @@ const newControlPanelTutorial = (app) => {
             position: 'bottom'
         },
         {
-            element: '[data-tutorial-id="control-panel-card-metrics"]',
-            title: '2. Seguimiento y Métricas',
-            content: 'Este módulo es para la gestión del equipo. Permite registrar la asistencia a reuniones y visualizar KPIs de ausentismo.',
-            position: 'top',
-            preAction: async () => { await app.switchView('control_ecrs'); }
-        },
-        {
-            element: '[data-tutorial-id="ecr-seguimiento-view-container"]',
-            title: 'Dashboard de Seguimiento',
-            content: 'Aquí puedes registrar la asistencia a las reuniones de ECR y ver gráficos sobre la participación de cada departamento.',
-            position: 'center',
-            preAction: async () => { await app.switchView('ecr_seguimiento'); }
-        },
-        {
             element: '[data-tutorial-id="control-panel-card-indicators"]',
-            title: '3. Indicadores de Gestión (ECM)',
-            content: 'Finalmente, este módulo ofrece una vista de alto nivel del rendimiento del proceso de cambios (ECM), con KPIs sobre ECRs y ECOs.',
+            title: '2. Indicadores de Gestión (ECM)',
+            content: 'Este módulo ofrece una vista de alto nivel del rendimiento del proceso de cambios (ECM), con KPIs sobre ECRs y ECOs.',
             position: 'top',
             preAction: async () => { await app.switchView('control_ecrs'); }
         },
@@ -91,6 +77,20 @@ const newControlPanelTutorial = (app) => {
             content: 'Este es el dashboard de ECM. Aquí puedes analizar métricas y KPIs sobre el proceso de ECRs y ECOs para identificar cuellos de botella y medir la eficiencia.',
             position: 'center',
             preAction: async () => { await app.switchView('indicadores_ecm_view'); }
+        },
+        {
+            element: '[data-tutorial-id="control-panel-card-metrics"]',
+            title: '3. Seguimiento y Métricas',
+            content: 'Finalmente, este módulo es para la gestión del equipo. Permite registrar la asistencia a reuniones y visualizar KPIs de ausentismo.',
+            position: 'top',
+            preAction: async () => { await app.switchView('control_ecrs'); }
+        },
+        {
+            element: '[data-tutorial-id="ecr-seguimiento-view-container"]',
+            title: 'Dashboard de Seguimiento',
+            content: 'Aquí puedes registrar la asistencia a las reuniones de ECR y ver gráficos sobre la participación de cada departamento.',
+            position: 'center',
+            preAction: async () => { await app.switchView('ecr_seguimiento'); }
         },
         {
             element: 'body',


### PR DESCRIPTION
The control panel tutorial was presenting steps in an order that did not match the visual layout of the UI. It would explain the first module, then the third, then the second, causing confusion.

This commit fixes the issue by:
- Reordering the step definitions in `public/new-control-panel-tutorial.js` to match the visual order of the cards on the screen (Table -> Indicators -> Metrics).
- Correcting the numbered titles within the tutorial steps to reflect the new, logical order.