### PR TITLE
feat: Implement version history for ECR forms

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -4613,7 +4613,17 @@ async function runEcrFormLogic(params = null) {
         showToast('Guardando formulario ECR...', 'info');
         try {
             const docRef = doc(db, COLLECTIONS.ECR_FORMS, ecrId);
-            await setDoc(docRef, dataToSave, { merge: true });
+            const historyRef = collection(docRef, 'history');
+            const batch = writeBatch(db);
+
+            // Set the main document (latest version)
+            batch.set(docRef, dataToSave, { merge: true });
+
+            // Add a new document to the history subcollection
+            const historyDocRef = doc(historyRef); // Auto-generate ID
+            batch.set(historyDocRef, dataToSave);
+
+            await batch.commit();
 
             localStorage.removeItem(ECR_FORM_STORAGE_KEY);
             showToast(`ECR "${ecrId}" guardado con éxito.`, 'success');


### PR DESCRIPTION
Refactors the `saveEcrForm` function in `public/main.js` to create a `history` subcollection in Firestore upon each save.

This change aligns the ECR form's behavior with the existing `saveEcoForm` function, which already includes versioning. It directly implements the first high-priority recommendation from the audit report (AUDIT_REPORT.md) to close a significant data integrity and auditability gap by ensuring that the entire lifecycle of an ECR is tracked.