### PR TITLE
Fix: Correct tutorial data and logic for PPAP step

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -1247,6 +1247,7 @@ async function createTutorialEcr() {
         situacion_propuesta: 'Esta es la situación propuesta para el ECR del tutorial, que permite la generación de un ECO.',
         // This field is checked by the ECO form logic
         cliente_requiere_ppap: true,
+        cliente_aprobacion_estado: 'aprobado',
         // Add a basic approvals structure so it looks realistic
         approvals: {
             ing_producto: { status: 'approved', user: 'Sistema', date: new Date().toISOString().split('T')[0], comment: 'Aprobado para tutorial' },
@@ -1978,7 +1979,7 @@ async function runEcoFormLogic(params = null) {
                     element.value = fieldsToPrepopulate[fieldName];
                 }
             }
-            if (ecrDataFromParam.cliente_requiere_ppap) {
+            if (ecrDataFromParam.cliente_requiere_ppap && ecrDataFromParam.cliente_aprobacion_estado === 'aprobado') {
                 const ppapContainer = formElement.querySelector('#ppap-confirmation-container');
                 if (ppapContainer) {
                     ppapContainer.classList.remove('hidden');


### PR DESCRIPTION
This commit addresses a bug in the ECR/ECO tutorial where the step for PPAP (Production Part Approval Process) was failing.

The investigation revealed two issues:
1. The tutorial data generation function (`createTutorialEcr`) was creating a sample ECR that required PPAP but was missing the necessary `cliente_aprobacion_estado: 'aprobado'` field.
2. The logic in the ECO form (`runEcoFormLogic`) was inconsistent. When creating an ECO from an ECR, it did not check for the client's approval status before showing the PPAP section, unlike the logic for editing an existing ECO.

This commit resolves both issues:
- Updates `createTutorialEcr` in `public/main.js` to include `cliente_aprobacion_estado: 'aprobado'` in the tutorial data.
- Modifies `runEcoFormLogic` in `public/main.js` to ensure the PPAP section is only shown if `cliente_requiere_ppap` is true AND `cliente_aprobacion_estado` is 'aprobado', making the logic consistent.

These changes ensure the tutorial runs correctly and improves the robustness of the application logic.