### PR TITLE
Fix(tutorial): Resolve race condition, tooltip, and highlight issues

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -1258,7 +1258,7 @@ async function createTutorialEcr() {
     try {
         await setDoc(ecrRef, tutorialEcrData);
         console.log(`Successfully created or updated tutorial ECR: ${ecrId}`);
-        return ecrId;
+        return tutorialEcrData; // Return the full object
     } catch (error) {
         console.error("Error creating tutorial ECR:", error);
         showToast('Error al preparar el ECR del tutorial.', 'error');
@@ -1702,8 +1702,12 @@ async function runEcoFormLogic(params = null) {
 
         function buildSectionHTML(section) {
             const checklistItemsHTML = section.checklist
-                ? section.checklist.map((item, index) => `
-                    <div class="checklist-item">
+            ? section.checklist.map((item, index) => {
+                const tutorialId = (section.id === 'implementacion' && index === 0)
+                    ? 'data-tutorial-id="action-plan-completion-checkbox"'
+                    : '';
+                return `
+                    <div class="checklist-item" ${tutorialId}>
                         <span class="checklist-item-label text-sm">${item}</span>
                         <div class="checklist-item-options">
                             <label class="text-sm font-medium">SI</label>
@@ -1711,8 +1715,9 @@ async function runEcoFormLogic(params = null) {
                             <label class="text-sm font-medium">N/A</label>
                             <input type="checkbox" name="check_${section.id}_${index}_na" class="form-checkbox h-5 w-5 text-gray-400">
                         </div>
-                    </div>
-                `).join('')
+                        </div>
+                `;
+            }).join('')
                 : '';
 
             const mainContentHTML = section.checklist


### PR DESCRIPTION
This commit addresses three distinct bugs in the ECR/ECO tutorial to ensure a smooth and correct user experience.

1.  **Fix Race Condition for PPAP Step:**
    - The tutorial previously created an ECR and immediately tried to read it back, leading to a race condition where the PPAP section would fail to appear.
    - The `createTutorialEcr` function in `main.js` is modified to return the full data object of the created ECR.
    - The tutorial's `postAction` now passes this data object directly to the `eco_form` view.
    - `runEcoFormLogic` is updated to use this passed-in data, eliminating the database re-fetch and resolving the race condition.
    - Added `cliente_aprobacion_estado: 'aprobado'` to the tutorial ECR data to satisfy the condition for showing the PPAP section.

2.  **Reposition Tooltip for Step 18:**
    - The tooltip for the 'ECO: Checklists Departamentales' step was positioned to the 'right', causing it to obscure content.
    - The `position` for this step in `tutorial.js` has been changed to 'top', ensuring the tooltip appears above the element without overlap.

3.  **Correct Element Highlight for Step 21:**
    - This step was incorrectly highlighting a generic section icon instead of the specific checkbox it describes.
    - A unique `data-tutorial-id` has been added to the '¿Plan de acción completado?' checklist item in `main.js`.
    - The tutorial step in `tutorial.js` has been updated to target this new, precise ID, ensuring the correct element is highlighted.