### PR TITLE
Fix(tutorial): Resolve race condition, tooltip, and highlight issues

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -1223,13 +1223,8 @@ async function createTutorialEcr() {
     const ecrId = 'TUTORIAL-ECR-001';
     const ecrRef = doc(db, COLLECTIONS.ECR_FORMS, ecrId);
 
-    // First, check if it already exists to avoid unnecessary writes
-    const docSnap = await getDoc(ecrRef);
-    if (docSnap.exists() && docSnap.data().status === 'approved') {
-        console.log('Tutorial ECR already exists and is approved.');
-        return ecrId; // It's already there, just return the ID
-    }
-
+    // Always overwrite the tutorial ECR to ensure it's fresh and correct.
+    // This prevents issues with stale data from previous tutorial runs.
     showToast('Preparando ECR de demostración para el tutorial...', 'info');
 
     const tutorialEcrData = {


### PR DESCRIPTION
This commit addresses three distinct bugs in the ECR/ECO tutorial to ensure a smooth and correct user experience.

1.  **Fix Race Condition for PPAP Step:**
    - The `createTutorialEcr` function in `main.js` now always overwrites the tutorial data. This prevents issues with stale data from previous tutorial runs, which was the root cause of the race condition.
    - The tutorial's `postAction` for the ECO generation step now gets the complete data object back from `createTutorialEcr` and passes it directly to the `eco_form` view. This eliminates the need for a database re-fetch and resolves the race condition permanently.
    - Added `cliente_aprobacion_estado: 'aprobado'` to the tutorial ECR data to satisfy the condition for showing the PPAP section.

2.  **Reposition Tooltip for Step 18:**
    - The tooltip for the 'ECO: Checklists Departamentales' step was positioned to the 'right', causing it to obscure content.
    - The `position` for this step in `tutorial.js` has been changed to 'top', ensuring the tooltip appears above the element without overlap.

3.  **Correct Element Highlight for Step 21:**
    - This step was incorrectly highlighting a generic section icon instead of the specific checkbox it describes.
    - A unique `data-tutorial-id` has been added to the '¿Plan de acción completado?' checklist item in `main.js`.
    - The tutorial step in `tutorial.js` has been updated to target this new, precise ID, ensuring the correct element is highlighted.