### PR TITLE
fix(deploy): Remove functions from firebase.json

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -6,9 +6,5 @@
       "**/.*",
       "**/node_modules/**"
     ]
-  },
-  "functions": {
-    "source": "functions",
-    "runtime": "nodejs18"
   }
 }


### PR DESCRIPTION
Removes the `"functions"` configuration block from `firebase.json`.

This prevents the Firebase CLI from attempting to deploy the (now empty) functions directory, which was triggering a check for the `cloudbuild.googleapis.com` API and causing the deployment to fail on the free "Spark" plan with an error requiring an upgrade to the "Blaze" plan.