### PR TITLE
Fix: Skip notifications collection when clearing data

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -577,7 +577,7 @@ function deleteItem(docId) {
 async function clearDataOnly() {
     showToast('Limpiando colecciones de datos...', 'info', 5000);
     const collectionNames = Object.values(COLLECTIONS);
-    const collectionsToSkip = [COLLECTIONS.USUARIOS, COLLECTIONS.TAREAS, COLLECTIONS.COVER_MASTER];
+    const collectionsToSkip = [COLLECTIONS.USUARIOS, COLLECTIONS.TAREAS, COLLECTIONS.COVER_MASTER, COLLECTIONS.NOTIFICATIONS];
     for (const name of collectionNames) {
         if (collectionsToSkip.includes(name)) {
             console.log(`Se omite la limpieza de la colección '${name}' para preservar los datos.`);


### PR DESCRIPTION
The `clearDataOnly` function was attempting to delete documents from the `notifications` collection. This failed with a "Missing or insufficient permissions" error for non-admin users, as they can only delete their own notifications.

This change adds the `notifications` collection to the list of collections to be skipped, preserving user notifications and preventing the error during the data clearing process.