### PR TITLE
fix(db): Prevent permission error when clearing database

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -577,7 +577,7 @@ function deleteItem(docId) {
 async function clearDataOnly() {
     showToast('Limpiando colecciones de datos...', 'info', 5000);
     const collectionNames = Object.values(COLLECTIONS);
-    const collectionsToSkip = [COLLECTIONS.USUARIOS, COLLECTIONS.TAREAS, COLLECTIONS.COVER_MASTER, COLLECTIONS.NOTIFICATIONS];
+    const collectionsToSkip = [COLLECTIONS.USUARIOS, COLLECTIONS.TAREAS, COLLECTIONS.COVER_MASTER, 'notifications'];
     for (const name of collectionNames) {
         if (collectionsToSkip.includes(name)) {
             console.log(`Se omite la limpieza de la colección '${name}' para preservar los datos.`);


### PR DESCRIPTION
The `clearDataOnly` function was throwing a 'Missing or insufficient permissions' error when attempting to delete documents from the `notifications` collection.

This occurs because the Firestore security rules correctly prevent a non-admin user from deleting notifications that do not belong to them.

The function already intended to skip this collection, along with others like 'usuarios' and 'tareas', but it was failing to do so, likely due to a subtle environment-specific bug.

This commit makes the fix more robust by hardcoding the string 'notifications' into the array of collections to be skipped. This guarantees the function respects the security rules by not attempting an operation it doesn't have permission for, thus resolving the error.