### PR TITLE
fix(firestore): Correct permissions for counters collection

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -208,10 +208,11 @@ service cloud.firestore {
     }
 
     // --- COUNTERS ---
-    // Allow any authenticated user to read/write to the counters collection.
-    // This is necessary for the client-side transaction to generate new ECR numbers.
+    // Allow any authenticated user to read the counters collection for KPIs.
+    // Writes are only performed by server-side functions with admin privileges.
     match /counters/{docId} {
-      allow read, write: if request.auth != null;
+      allow read: if request.auth != null;
+      allow write: if false;
     }
 
     // --- NOTIFICACIONES ---


### PR DESCRIPTION
Updated the Firestore security rules to allow authenticated users to read from the `/counters/{docId}` collection. This resolves an issue where the KPI dashboard would fail to load data due to 'Missing or insufficient permissions'.

The rule has also been hardened to disallow client-side writes (`allow write: if false;`), as all counter updates are performed by server-side Cloud Functions with admin privileges. This improves the security of the application.