### PR TITLE
Debug(firestore): Temporarily open counter reads for debugging

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -212,7 +212,8 @@ service cloud.firestore {
     // We use specific rules for each type of counter.
     match /counters/{counterDoc} {
         // Allow any authenticated user to read any document in the collection.
-        allow read: if request.auth != null;
+        // TEMPORARY DEBUGGING RULE: Open read access to isolate the problem.
+        allow read: if true;
 
         // Allow writes ONLY to the 'ecr_counter' document for authenticated users.
         allow write: if request.auth != null && counterDoc == 'ecr_counter';


### PR DESCRIPTION
This is a temporary commit for debugging purposes only.

After multiple failed attempts to fix a persistent "permission denied" error on the `/counters` collection, this change opens up read access to `if true`.

This is intended to definitively determine if the problem lies with the `request.auth` object being nullified for this specific path, or if it's a deeper issue.

This change is insecure and must be reverted after the test.