### PR TITLE
Fix: Configure firebase.json to deploy Firestore rules

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,4 +1,8 @@
 {
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
+  },
   "hosting": {
     "public": "public",
     "ignore": [

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,4 @@
+{
+  "indexes": [],
+  "fieldOverrides": []
+}

--- a/public/main.js
+++ b/public/main.js
@@ -335,29 +335,18 @@ async function startRealtimeListeners() {
     }
 
     // --- Real-time listener for KPI counts ---
-    // The previous diagnostic test confirmed the issue is a race condition with auth state,
-    // not the rules themselves. The fix is to restore the onSnapshot listener but ensure
-    // it is instantiated within the main async function's execution context.
-    try {
-        const kpiCounterRef = doc(db, 'counters', 'kpi_counts');
-        const kpiUnsub = onSnapshot(kpiCounterRef, (doc) => {
-            if (doc.exists()) {
-                const counts = doc.data();
-                appState.collectionCounts = { ...appState.collectionCounts, ...counts };
-                console.log("Dashboard KPI counts updated in real-time:", appState.collectionCounts);
-                if (appState.currentView === 'dashboard') {
-                    renderDashboardKpis();
-                }
+    const kpiCounterRef = doc(db, 'counters', 'kpi_counts');
+    const kpiUnsub = onSnapshot(kpiCounterRef, (doc) => {
+        if (doc.exists()) {
+            const counts = doc.data();
+            appState.collectionCounts = { ...appState.collectionCounts, ...counts };
+            console.log("Dashboard KPI counts updated in real-time:", appState.collectionCounts);
+            if (appState.currentView === 'dashboard') {
+                renderDashboardKpis();
             }
-        }, (error) => {
-            // This error handler is for issues after the listener is established.
-            console.error("Error listening to KPI counters:", error);
-        });
-        listeners.push(kpiUnsub);
-    } catch (error) {
-        // This error handler is for issues during the initial setup of the listener.
-        console.error("Error ATTACHING KPI counters listener:", error);
-    }
+        }
+    }, (error) => console.error("Error listening to KPI counters:", error));
+    listeners.push(kpiUnsub);
 
     // --- Listener for user's most recent tasks for the dashboard ---
     const tasksQuery = query(


### PR DESCRIPTION
The root cause of the persistent "Missing or insufficient permissions" error was an incomplete `firebase.json` file. The file was missing the "firestore" configuration block, which meant that the `firestore.rules` file was never being deployed to the Firebase project. The database was operating under the default security rules, which deny all reads and writes.

This commit introduces the following fixes:
1.  Updates `firebase.json` to include the necessary configuration to deploy Firestore rules and indexes.
2.  Adds a standard, empty `firestore.indexes.json` file to prevent deployment warnings.
3.  Restores `main.js` to its original state, as the client-side code was not the cause of the error.

With this change, running `firebase deploy` will now correctly apply the security rules defined in `firestore.rules`, resolving the permission errors across the application.