### PR TITLE
This commit removes a call to the non-existent function `destroyDashb…

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -1366,9 +1366,6 @@ function setupGlobalEventListeners() {
 }
 
 async function switchView(viewName, params = null) {
-    if (appState.currentView === 'dashboard') {
-        destroyDashboardCharts();
-    }
     if (appState.currentViewCleanup) {
         appState.currentViewCleanup();
         appState.currentViewCleanup = null;


### PR DESCRIPTION
…oardCharts` within the `switchView` function. This was a remnant from a previous refactor and was causing a runtime error when navigating away from the dashboard.