### PR TITLE
This commit fixes a ReferenceError in the `runDashboardLogic` functio…

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -6403,7 +6403,7 @@ async function runDashboardLogic() {
     const tasksPromise = fetchDashboardTasks();
     const projectsPromise = getDocs(collection(db, COLLECTIONS.PROYECTOS));
 
-    const [kpiData, tasks, projectsSnap] = await Promise.all([kpiPromise, tasksPromise, projectsSnap]);
+    const [kpiData, tasks, projectsSnap] = await Promise.all([kpiPromise, tasksPromise, projectsPromise]);
 
     const projects = projectsSnap.docs.map(doc => ({ ...doc.data(), docId: doc.id }));
 


### PR DESCRIPTION
…n. A variable (`projectsSnap`) was used in a `Promise.all` array before it was initialized, instead of the correct promise variable (`projectsPromise`). This typo broke the dashboard loading sequence.