### PR TITLE
This commit fixes a ReferenceError by declaring the `dashboardCharts`…

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -280,6 +280,8 @@ const dom = {
     userMenuContainer: document.getElementById('user-menu-container'),
 };
 
+const dashboardCharts = {};
+
 // =================================================================================
 // --- 3. LÓGICA DE DATOS (FIRESTORE) ---
 // =================================================================================


### PR DESCRIPTION
… object in the global scope. This object is used to manage chart instances for the dashboard and was accidentally removed during a previous refactor, causing a runtime error.