### PR TITLE
fix(eco): Correct PPAP validation logic in ECO form

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -5,7 +5,7 @@ import { initializeApp } from "https://www.gstatic.com/firebasejs/9.15.0/firebas
 import { getAuth, onAuthStateChanged, createUserWithEmailAndPassword, signInWithEmailAndPassword, sendPasswordResetEmail, signOut, updatePassword, reauthenticateWithCredential, EmailAuthProvider, deleteUser, sendEmailVerification, updateProfile } from "https://www.gstatic.com/firebasejs/9.15.0/firebase-auth.js";
 import { getFirestore, collection, doc, getDoc, getDocs, setDoc, addDoc, updateDoc, deleteDoc, query, where, onSnapshot, writeBatch, runTransaction, orderBy, limit, startAfter, or, getCountFromServer } from "https://www.gstatic.com/firebasejs/9.15.0/firebase-firestore.js";
 import { getFunctions, httpsCallable } from "https://www.gstatic.com/firebasejs/9.15.0/firebase-functions.js";
-import { COLLECTIONS, getUniqueKeyForCollection, createHelpTooltip } from './utils.js';
+import { COLLECTIONS, getUniqueKeyForCollection, createHelpTooltip, shouldRequirePpapConfirmation } from './utils.js';
 import { deleteProductAndOrphanedSubProducts } from './data_logic.js';
 import tutorial from './tutorial.js';
 import newControlPanelTutorial from './new-control-panel-tutorial.js';
@@ -1914,7 +1914,7 @@ async function runEcoFormLogic(params = null) {
                     ecrDocSnap = await getDoc(ecrDocRef);
                 }
 
-                if (ecrDocSnap.exists() && ecrDocSnap.data().cliente_requiere_ppap && ecrDocSnap.data().cliente_aprobacion_estado === 'aprobado') {
+                if (ecrDocSnap.exists() && shouldRequirePpapConfirmation(ecrDocSnap.data())) {
                     const ppapContainer = formElement.querySelector('#ppap-confirmation-container');
                     if (ppapContainer) {
                         ppapContainer.classList.remove('hidden');
@@ -1943,7 +1943,7 @@ async function runEcoFormLogic(params = null) {
                     element.value = fieldsToPrepopulate[fieldName];
                 }
             }
-            if (ecrDataFromParam.cliente_requiere_ppap && ecrDataFromParam.cliente_aprobacion_estado === 'aprobado') {
+            if (shouldRequirePpapConfirmation(ecrDataFromParam)) {
                 const ppapContainer = formElement.querySelector('#ppap-confirmation-container');
                 if (ppapContainer) {
                     ppapContainer.classList.remove('hidden');
@@ -2088,9 +2088,9 @@ async function runEcoFormLogic(params = null) {
             if (ecrNo) {
                 const ecrDocRef = doc(db, COLLECTIONS.ECR_FORMS, ecrNo);
                 const ecrDocSnap = await getDoc(ecrDocRef);
-                if (ecrDocSnap.exists() && ecrDocSnap.data().cliente_requiere_ppap) {
+                if (ecrDocSnap.exists() && shouldRequirePpapConfirmation(ecrDocSnap.data())) {
                     const ppapContainer = document.getElementById('ppap-confirmation-container');
-                    ppapContainer.classList.remove('hidden'); // Make sure it's visible
+                    // No need to remove hidden here, as the container should already be visible if this logic runs.
                     const ppapCheckbox = formElement.querySelector('[name="ppap_completed_confirmation"]');
                     if (!ppapCheckbox.checked) {
                         errorMessages.push('Se requiere confirmación de PPAP antes de aprobar este ECO.');

--- a/public/utils.js
+++ b/public/utils.js
@@ -47,3 +47,18 @@ export function createHelpTooltip(message) {
         </div>
     `;
 }
+
+/**
+ * Determines if the PPAP confirmation checkbox should be required and validated for an ECO.
+ * The condition is that PPAP is required by the client AND the client has formally approved it.
+ * @param {object} ecrData - The data object from the associated ECR document.
+ * @returns {boolean} - True if PPAP confirmation is required, false otherwise.
+ */
+export function shouldRequirePpapConfirmation(ecrData) {
+    if (!ecrData) {
+        return false;
+    }
+    // The logic is that the PPAP confirmation is only relevant if the ECR
+    // both requires a PPAP and the client has given their final approval.
+    return !!ecrData.cliente_requiere_ppap && ecrData.cliente_aprobacion_estado === 'aprobado';
+}

--- a/tests/unit/utils.spec.js
+++ b/tests/unit/utils.spec.js
@@ -1,4 +1,4 @@
-import { getUniqueKeyForCollection, createHelpTooltip, COLLECTIONS } from '../../public/utils.js';
+import { getUniqueKeyForCollection, createHelpTooltip, shouldRequirePpapConfirmation, COLLECTIONS } from '../../public/utils.js';
 
 describe('getUniqueKeyForCollection', () => {
   test('should return "codigo_pieza" for PRODUCTOS', () => {
@@ -71,4 +71,56 @@ describe('createHelpTooltip', () => {
     expect(id2).not.toBeNull();
     expect(id1).not.toEqual(id2);
   });
+});
+
+describe('shouldRequirePpapConfirmation', () => {
+    // Test case 1: The correct condition to require PPAP confirmation
+    test('should return true when PPAP is required and client approval is "aprobado"', () => {
+        const ecrData = {
+            cliente_requiere_ppap: true,
+            cliente_aprobacion_estado: 'aprobado'
+        };
+        expect(shouldRequirePpapConfirmation(ecrData)).toBe(true);
+    });
+
+    // Test case 2: The scenario that was causing the bug
+    test('should return false when PPAP is required but client approval is "pendiente"', () => {
+        const ecrData = {
+            cliente_requiere_ppap: true,
+            cliente_aprobacion_estado: 'pendiente'
+        };
+        expect(shouldRequirePpapConfirmation(ecrData)).toBe(false);
+    });
+
+    // Test case 3: Another buggy scenario
+    test('should return false when PPAP is required but client approval is "rechazado"', () => {
+        const ecrData = {
+            cliente_requiere_ppap: true,
+            cliente_aprobacion_estado: 'rechazado'
+        };
+        expect(shouldRequirePpapConfirmation(ecrData)).toBe(false);
+    });
+
+    // Test case 4: PPAP not required
+    test('should return false when PPAP is not required, regardless of approval status', () => {
+        const ecrData = {
+            cliente_requiere_ppap: false,
+            cliente_aprobacion_estado: 'aprobado'
+        };
+        expect(shouldRequirePpapConfirmation(ecrData)).toBe(false);
+    });
+
+    // Test case 5: Edge case with missing data
+    test('should return false if ecrData is null or undefined', () => {
+        expect(shouldRequirePpapConfirmation(null)).toBe(false);
+        expect(shouldRequirePpapConfirmation(undefined)).toBe(false);
+    });
+
+    // Test case 6: Edge case with missing properties
+    test('should return false if required properties are missing', () => {
+        const ecrData1 = { cliente_aprobacion_estado: 'aprobado' }; // Missing cliente_requiere_ppap
+        const ecrData2 = { cliente_requiere_ppap: true }; // Missing cliente_aprobacion_estado
+        expect(shouldRequirePpapConfirmation(ecrData1)).toBe(false);
+        expect(shouldRequirePpapConfirmation(ecrData2)).toBe(false);
+    });
 });


### PR DESCRIPTION
The ECO form validation was incorrectly requiring PPAP confirmation even when the client's approval for the ECR was still pending or rejected. This would block users from approving an ECO, as the checkbox to confirm PPAP was correctly hidden from the UI in these states, but the validation logic still required it to be checked.

This commit fixes the bug by:
1.  Creating a new, centralized utility function `shouldRequirePpapConfirmation` in `utils.js` that encapsulates the correct logic: confirmation is required only if PPAP is needed AND the client has approved the ECR.
2.  Refactoring the three locations in `main.js` (ECO form population on create, on edit, and in the final validation) to use this single, correct function.
3.  Adding a new unit test suite for the `shouldRequirePpapConfirmation` function to verify its behavior and prevent regressions.