### PR TITLE
fix(data): Use correct unique key in orphan deletion logic

### DIFF
--- a/public/data_logic.js
+++ b/public/data_logic.js
@@ -1,5 +1,7 @@
 // No longer importing from firebase here. The functions will be passed in.
 
+import { getUniqueKeyForCollection } from './utils.js';
+
 export async function deleteProductAndOrphanedSubProducts(productDocId, db, firestore, COLLECTIONS, uiCallbacks) {
     // Destructure the required firestore functions from the passed-in object
     const { doc, getDoc, getDocs, deleteDoc, collection, query, where } = firestore;
@@ -73,7 +75,8 @@ export async function deleteProductAndOrphanedSubProducts(productDocId, db, fire
             }
 
             if (!isUsedElsewhere) {
-                const q = query(collection(db, COLLECTIONS.SEMITERMINADOS), where("id", "==", subProductRefId));
+                const uniqueKeyField = getUniqueKeyForCollection(COLLECTIONS.SEMITERMINADOS);
+                const q = query(collection(db, COLLECTIONS.SEMITERMINADOS), where(uniqueKeyField, "==", subProductRefId));
                 const subProductToDeleteSnap = await getDocs(q);
                 if (!subProductToDeleteSnap.empty) {
                     const subProductDocToDelete = subProductToDeleteSnap.docs[0];

--- a/tests/unit/data_logic.spec.js
+++ b/tests/unit/data_logic.spec.js
@@ -1,5 +1,6 @@
 import { jest, describe, test, expect, beforeEach } from '@jest/globals';
 import { deleteProductAndOrphanedSubProducts } from '../../public/data_logic.js';
+import { COLLECTIONS } from '../../public/utils.js';
 
 // Mock de UI Callbacks
 const mockUiCallbacks = {
@@ -9,10 +10,6 @@ const mockUiCallbacks = {
 
 // Mock de la base de datos y colecciones
 const mockDb = {};
-const mockCollections = {
-    PRODUCTOS: 'productos',
-    SEMITERMINADOS: 'semiterminados',
-};
 
 // Mock del objeto firestore
 const mockFirestore = {
@@ -46,7 +43,7 @@ describe('deleteProductAndOrphanedSubProducts', () => {
             .mockResolvedValueOnce({ empty: false, docs: [{ id: 'SUB001_DOC_ID', data: () => subProductToDelete }] }); // find sub-product to delete
 
         // Act
-        await deleteProductAndOrphanedSubProducts('PROD001', mockDb, mockFirestore, mockCollections, mockUiCallbacks);
+        await deleteProductAndOrphanedSubProducts('PROD001', mockDb, mockFirestore, COLLECTIONS, mockUiCallbacks);
 
         // Assert
         expect(mockFirestore.deleteDoc).toHaveBeenCalledTimes(2);
@@ -71,7 +68,7 @@ describe('deleteProductAndOrphanedSubProducts', () => {
         mockFirestore.getDocs.mockResolvedValueOnce({ docs: [{ data: () => otherProduct }] });
 
         // Act
-        await deleteProductAndOrphanedSubProducts('PROD001', mockDb, mockFirestore, mockCollections, mockUiCallbacks);
+        await deleteProductAndOrphanedSubProducts('PROD001', mockDb, mockFirestore, COLLECTIONS, mockUiCallbacks);
 
         // Assert
         expect(mockFirestore.deleteDoc).toHaveBeenCalledTimes(1);
@@ -90,7 +87,7 @@ describe('deleteProductAndOrphanedSubProducts', () => {
         mockFirestore.getDoc.mockResolvedValueOnce({ exists: () => true, data: () => productToDelete });
 
         // Act
-        await deleteProductAndOrphanedSubProducts('PROD001', mockDb, mockFirestore, mockCollections, mockUiCallbacks);
+        await deleteProductAndOrphanedSubProducts('PROD001', mockDb, mockFirestore, COLLECTIONS, mockUiCallbacks);
 
         // Assert
         expect(mockFirestore.deleteDoc).toHaveBeenCalledTimes(1);
@@ -104,7 +101,7 @@ describe('deleteProductAndOrphanedSubProducts', () => {
         mockFirestore.getDoc.mockResolvedValueOnce({ exists: () => false });
 
         // Act
-        await deleteProductAndOrphanedSubProducts('NON_EXISTENT_PROD', mockDb, mockFirestore, mockCollections, mockUiCallbacks);
+        await deleteProductAndOrphanedSubProducts('NON_EXISTENT_PROD', mockDb, mockFirestore, COLLECTIONS, mockUiCallbacks);
 
         // Assert
         expect(mockFirestore.deleteDoc).not.toHaveBeenCalled();
@@ -135,7 +132,7 @@ describe('deleteProductAndOrphanedSubProducts', () => {
             .mockResolvedValueOnce({ empty: false, docs: [{ id: 'SUB002_DOC_ID', data: () => subProduct2 }] });
 
         // Act
-        await deleteProductAndOrphanedSubProducts('PROD001', mockDb, mockFirestore, mockCollections, mockUiCallbacks);
+        await deleteProductAndOrphanedSubProducts('PROD001', mockDb, mockFirestore, COLLECTIONS, mockUiCallbacks);
 
         // Assert
         expect(mockFirestore.deleteDoc).toHaveBeenCalledTimes(3);
@@ -148,7 +145,7 @@ describe('deleteProductAndOrphanedSubProducts', () => {
         mockFirestore.getDoc.mockRejectedValue(error);
 
         // Act
-        await deleteProductAndOrphanedSubProducts('PROD001', mockDb, mockFirestore, mockCollections, mockUiCallbacks);
+        await deleteProductAndOrphanedSubProducts('PROD001', mockDb, mockFirestore, COLLECTIONS, mockUiCallbacks);
 
         // Assert
         expect(mockUiCallbacks.showToast).toHaveBeenCalledWith('Ocurrió un error durante la eliminación compleja.', 'error');
@@ -167,7 +164,7 @@ describe('deleteProductAndOrphanedSubProducts', () => {
             .mockResolvedValueOnce({ empty: true, docs: [] }); // sub-product not found
 
         // Act
-        await deleteProductAndOrphanedSubProducts('PROD001', mockDb, mockFirestore, mockCollections, mockUiCallbacks);
+        await deleteProductAndOrphanedSubProducts('PROD001', mockDb, mockFirestore, COLLECTIONS, mockUiCallbacks);
 
         // Assert
         expect(mockFirestore.deleteDoc).toHaveBeenCalledTimes(1); // Only the main product
@@ -200,7 +197,7 @@ describe('deleteProductAndOrphanedSubProducts', () => {
             .mockResolvedValueOnce({ empty: false, docs: [{ id: 'SUB001_DOC_ID', data: () => subProductToDelete }] });
 
         // Act
-        await deleteProductAndOrphanedSubProducts('PROD001', mockDb, mockFirestore, mockCollections, mockUiCallbacks);
+        await deleteProductAndOrphanedSubProducts('PROD001', mockDb, mockFirestore, COLLECTIONS, mockUiCallbacks);
 
         // Assert
         expect(mockFirestore.deleteDoc).toHaveBeenCalledTimes(2);
@@ -225,9 +222,80 @@ describe('deleteProductAndOrphanedSubProducts', () => {
             .mockResolvedValueOnce({ empty: false, docs: [{ id: 'SUB001_DOC_ID', data: () => subProductToDelete }] });
 
         // Act
-        await deleteProductAndOrphanedSubProducts('PROD001', mockDb, mockFirestore, mockCollections, mockUiCallbacks);
+        await deleteProductAndOrphanedSubProducts('PROD001', mockDb, mockFirestore, COLLECTIONS, mockUiCallbacks);
 
         // Assert
         expect(mockFirestore.deleteDoc).toHaveBeenCalledTimes(2);
+    });
+
+    test('BUGFIX: should delete an orphaned semiterminado by its unique key (codigo_pieza) even if it lacks an "id" field', async () => {
+        // --- 1. SETUP ---
+
+        // Mock the main product to be deleted
+        const mainProduct = {
+            docId: 'product-to-delete',
+            estructura: [
+                {
+                    tipo: 'semiterminado',
+                    refId: 'orphan-sub-123', // This is the 'codigo_pieza'
+                    children: []
+                }
+            ]
+        };
+        mockFirestore.getDoc.mockResolvedValueOnce({
+            exists: () => true,
+            data: () => mainProduct
+        });
+
+        // Mock the query for all other products (return an empty list, so the sub-product is an orphan)
+        mockFirestore.getDocs.mockResolvedValueOnce({
+            docs: [],
+            empty: true
+        });
+
+        // Mock the query for the orphaned semiterminado.
+        // This is the key part of the test: the returned document has 'codigo_pieza' but NO 'id' field.
+        const orphanedSubProductDoc = {
+            id: 'doc-id-in-firestore', // The actual document ID in Firestore that we want to delete
+            data: () => ({
+                codigo_pieza: 'orphan-sub-123',
+                descripcion: 'An orphaned sub-product.'
+                // NOTE: This mock deliberately does NOT have an 'id' field in its data.
+            })
+        };
+        const orphanedQuerySnapshot = {
+            docs: [orphanedSubProductDoc],
+            empty: false
+        };
+        // This mock is for the query inside the loop that searches for the orphan to delete.
+        mockFirestore.getDocs.mockResolvedValueOnce(orphanedQuerySnapshot);
+
+        // --- 2. EXECUTION ---
+        await deleteProductAndOrphanedSubProducts(
+            mainProduct.docId,
+            mockDb,
+            mockFirestore,
+            COLLECTIONS,
+            mockUiCallbacks
+        );
+
+        // --- 3. ASSERTIONS ---
+
+        // It should query using the correct unique key 'codigo_pieza' because of the fix.
+        expect(mockFirestore.where).toHaveBeenCalledWith('codigo_pieza', '==', 'orphan-sub-123');
+
+        // It should NOT have tried to query using the old, buggy 'id' field.
+        expect(mockFirestore.where).not.toHaveBeenCalledWith('id', '==', 'orphan-sub-123');
+
+        // Most importantly, it should have called deleteDoc with the correct document reference.
+        // It's called twice: once for the main product, once for the orphan.
+        expect(mockFirestore.deleteDoc).toHaveBeenCalledTimes(2);
+        expect(mockFirestore.deleteDoc).toHaveBeenCalledWith(
+             mockFirestore.doc(mockDb, COLLECTIONS.SEMITERMINADOS, orphanedSubProductDoc.id)
+        );
+
+        // Check if user feedback was appropriate.
+        expect(mockUiCallbacks.showToast).toHaveBeenCalledWith('1 sub-componentes huérfanos eliminados.', 'success');
+        expect(mockUiCallbacks.runTableLogic).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
The `deleteProductAndOrphanedSubProducts` function was hardcoded to query for orphaned `semiterminado` documents using an `id` field.

This is incorrect, as the unique key for this collection is `codigo_pieza`. This could lead to orphaned documents not being deleted if they were created without the redundant `id` field.

This commit fixes the issue by using the `getUniqueKeyForCollection` utility to dynamically determine the correct unique key for the query. A new unit test is added to verify the fix.