### PR TITLE
feat: Add number validation to forms and refactor for testability

### DIFF
--- a/public/utils.js
+++ b/public/utils.js
@@ -62,3 +62,35 @@ export function shouldRequirePpapConfirmation(ecrData) {
     // both requires a PPAP and the client has given their final approval.
     return !!ecrData.cliente_requiere_ppap && ecrData.cliente_aprobacion_estado === 'aprobado';
 }
+
+/**
+ * Validates a single form field based on its configuration.
+ * @param {object} fieldConfig - The configuration object for the field from viewConfig.
+ * @param {HTMLInputElement} inputElement - The DOM element for the input.
+ * @returns {boolean} - True if the field is valid, false otherwise.
+ */
+export function validateField(fieldConfig, inputElement) {
+    const errorElement = document.getElementById(`error-${fieldConfig.key}`);
+    let isValid = true;
+    let errorMessage = '';
+
+    const value = inputElement.value.trim();
+
+    // Check for required fields
+    if (fieldConfig.required && !value) {
+        isValid = false;
+        errorMessage = 'Este campo es obligatorio.';
+    }
+    // Check for number types, but only if a value is present
+    else if (fieldConfig.type === 'number' && value && isNaN(Number(value))) {
+        isValid = false;
+        errorMessage = 'Debe ingresar un valor numérico.';
+    }
+
+    if (errorElement) {
+        errorElement.textContent = errorMessage;
+    }
+    inputElement.classList.toggle('border-red-500', !isValid);
+    inputElement.classList.toggle('border-gray-300', isValid);
+    return isValid;
+}

--- a/tests/unit/ecr_approval.spec.js
+++ b/tests/unit/ecr_approval.spec.js
@@ -1,0 +1,151 @@
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+// Import the function to be tested directly from its new, isolated location.
+import { registerEcrApproval } from '../../public/data_logic.js';
+// We still need the real COLLECTIONS object.
+import { COLLECTIONS } from '../../public/utils.js';
+
+// --- Mocks Setup ---
+// We only need to mock the dependencies that are passed into the function.
+
+const mockShowToast = jest.fn();
+const mockSendNotification = jest.fn();
+const mockGetDoc = jest.fn();
+const mockUpdateDoc = jest.fn();
+const mockRunTransaction = jest.fn();
+
+// This object simulates the `firestore` dependency that will be passed in.
+const mockFirestore = {
+    doc: jest.fn((db, collection, id) => ({ db, collection, id, path: `${collection}/${id}` })),
+    getDoc: mockGetDoc,
+    runTransaction: mockRunTransaction,
+};
+
+// This object simulates the `uiCallbacks` dependency.
+const mockUiCallbacks = {
+    showToast: mockShowToast,
+    sendNotification: mockSendNotification,
+};
+
+// A mock for the global appState.
+const mockAppState = {
+    currentUser: {
+        name: 'Test User',
+        email: 'test@barack.com',
+        sector: 'calidad',
+        role: 'admin',
+    },
+};
+
+// --- Test Suite ---
+
+describe('registerEcrApproval State Machine', () => {
+    beforeEach(() => {
+        // Clear all mock function call histories before each test
+        jest.clearAllMocks();
+
+        // Provide a fresh implementation for the transaction mock for each test
+        mockRunTransaction.mockImplementation(async (db, updateFunction) => {
+            // This object simulates the `transaction` object that Firestore provides.
+            const transaction = {
+                get: mockGetDoc, // It has a `get` method
+                update: mockUpdateDoc, // and an `update` method
+            };
+            // The `updateFunction` is the code we are testing. We call it with our mock transaction.
+            await updateFunction(transaction);
+        });
+    });
+
+    test('[BUG-REPRO] should transition ECR status to "approved" when the last required department approves', async () => {
+        // --- 1. ARRANGE ---
+        const ecrId = 'ECR-BUG-001';
+        const initialEcrData = {
+            id: ecrId,
+            status: 'pending-approval',
+            afecta_calidad: true,
+            afecta_compras: true,
+            afecta_logistica: false,
+            approvals: {
+                calidad: { status: 'approved', user: 'Calidad User', date: '2023-01-01', comment: 'OK' }
+            }
+        };
+
+        // Configure the mock for `transaction.get()` to return our test data.
+        mockGetDoc.mockResolvedValue({ exists: () => true, data: () => JSON.parse(JSON.stringify(initialEcrData)) });
+
+        // Set the current user to be the one from the 'compras' department for this test run.
+        mockAppState.currentUser.sector = 'compras';
+
+        const deps = {
+            db: 'mockDb',
+            firestore: mockFirestore,
+            COLLECTIONS,
+            appState: mockAppState,
+            uiCallbacks: mockUiCallbacks,
+        };
+
+        // --- 2. ACT ---
+        // The user from 'compras' submits the final required approval.
+        await registerEcrApproval(ecrId, 'compras', 'approved', 'Final approval.', deps);
+
+        // --- 3. ASSERT ---
+        expect(mockUpdateDoc).toHaveBeenCalledTimes(1);
+        const updateCallArgs = mockUpdateDoc.mock.calls[0][1];
+
+        expect(updateCallArgs['approvals.compras'].status).toBe('approved');
+
+        // This is the assertion that is expected to fail.
+        expect(updateCallArgs.status).toBe('approved');
+    });
+
+    test('should transition ECR status to "rejected" when any required department rejects', async () => {
+        // --- ARRANGE ---
+        const ecrId = 'ECR-REJECT-001';
+        const initialEcrData = {
+            id: ecrId,
+            status: 'pending-approval',
+            afecta_calidad: true,
+            afecta_compras: true,
+            approvals: {
+                 calidad: { status: 'approved', user: 'Calidad User', date: '2023-01-01', comment: 'OK' }
+            }
+        };
+        mockGetDoc.mockResolvedValue({ exists: () => true, data: () => JSON.parse(JSON.stringify(initialEcrData)) });
+        mockAppState.currentUser.sector = 'compras';
+        const deps = { db: 'mockDb', firestore: mockFirestore, COLLECTIONS, appState: mockAppState, uiCallbacks: mockUiCallbacks };
+
+        // --- ACT ---
+        await registerEcrApproval(ecrId, 'compras', 'rejected', 'Not viable.', deps);
+
+        // --- ASSERT ---
+        expect(mockUpdateDoc).toHaveBeenCalledTimes(1);
+        const updateCallArgs = mockUpdateDoc.mock.calls[0][1];
+        expect(updateCallArgs['approvals.compras'].status).toBe('rejected');
+        expect(updateCallArgs.status).toBe('rejected');
+    });
+
+    test('should remain "pending-approval" when a required department approves but others are still pending', async () => {
+        // --- ARRANGE ---
+        const ecrId = 'ECR-PENDING-001';
+        const initialEcrData = {
+            id: ecrId,
+            status: 'pending-approval',
+            afecta_calidad: true,
+            afecta_compras: true,
+            approvals: {} // No approvals yet
+        };
+        mockGetDoc.mockResolvedValue({ exists: () => true, data: () => JSON.parse(JSON.stringify(initialEcrData)) });
+        mockAppState.currentUser.sector = 'calidad';
+        const deps = { db: 'mockDb', firestore: mockFirestore, COLLECTIONS, appState: mockAppState, uiCallbacks: mockUiCallbacks };
+
+        // --- ACT ---
+        await registerEcrApproval(ecrId, 'calidad', 'approved', 'First approval.', deps);
+
+        // --- ASSERT ---
+        expect(mockUpdateDoc).toHaveBeenCalledTimes(1);
+        const updateCallArgs = mockUpdateDoc.mock.calls[0][1];
+        expect(updateCallArgs['approvals.calidad'].status).toBe('approved');
+        // The overall status should NOT be in the update call, meaning it remains unchanged.
+        expect(updateCallArgs.status).toBeUndefined();
+    });
+});

--- a/tests/unit/form_validation.spec.js
+++ b/tests/unit/form_validation.spec.js
@@ -1,0 +1,84 @@
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+// Import the function directly from its new, testable location in utils.js
+import { validateField } from '../../public/utils.js';
+
+describe('validateField', () => {
+    let inputElement;
+    let errorElement;
+
+    beforeEach(() => {
+        // Set up a clean DOM for each test, simulating the elements the function needs
+        document.body.innerHTML = `
+            <div>
+                <input id="test-input" name="test-input">
+                <p id="error-test-input"></p>
+            </div>
+        `;
+        inputElement = document.getElementById('test-input');
+        errorElement = document.getElementById('error-test-input');
+    });
+
+    test('should return true for a valid required text field with value', () => {
+        const fieldConfig = { key: 'test-input', required: true, type: 'text' };
+        inputElement.value = 'Some text';
+        const isValid = validateField(fieldConfig, inputElement);
+        expect(isValid).toBe(true);
+        expect(inputElement.classList.contains('border-red-500')).toBe(false);
+        expect(errorElement.textContent).toBe('');
+    });
+
+    test('should return false for a required text field with no value', () => {
+        const fieldConfig = { key: 'test-input', required: true, type: 'text' };
+        inputElement.value = '';
+        const isValid = validateField(fieldConfig, inputElement);
+        expect(isValid).toBe(false);
+        expect(inputElement.classList.contains('border-red-500')).toBe(true);
+        expect(errorElement.textContent).toBe('Este campo es obligatorio.');
+    });
+
+    test('should return true for a valid number field', () => {
+        const fieldConfig = { key: 'test-input', required: true, type: 'number' };
+        inputElement.value = '123.45';
+        const isValid = validateField(fieldConfig, inputElement);
+        expect(isValid).toBe(true);
+        expect(inputElement.classList.contains('border-red-500')).toBe(false);
+        expect(errorElement.textContent).toBe('');
+    });
+
+    test('[BUG-VERIFY] should return false for a number field with non-numeric text', () => {
+        const fieldConfig = { key: 'test-input', required: true, type: 'number' };
+        inputElement.value = 'abc';
+        const isValid = validateField(fieldConfig, inputElement);
+        expect(isValid).toBe(false);
+        expect(inputElement.classList.contains('border-red-500')).toBe(true);
+        expect(errorElement.textContent).toBe('Debe ingresar un valor numérico.');
+    });
+
+    test('[BUG-VERIFY] should return false for a number field with mixed text', () => {
+        const fieldConfig = { key: 'test-input', required: true, type: 'number' };
+        inputElement.value = '123a';
+        const isValid = validateField(fieldConfig, inputElement);
+        expect(isValid).toBe(false);
+        expect(inputElement.classList.contains('border-red-500')).toBe(true);
+        expect(errorElement.textContent).toBe('Debe ingresar un valor numérico.');
+    });
+
+    test('should return true for a non-required number field that is empty', () => {
+        const fieldConfig = { key: 'test-input', required: false, type: 'number' };
+        inputElement.value = '';
+        const isValid = validateField(fieldConfig, inputElement);
+        expect(isValid).toBe(true);
+        expect(inputElement.classList.contains('border-red-500')).toBe(false);
+        expect(errorElement.textContent).toBe('');
+    });
+
+    test('should return false for a required number field that is empty', () => {
+        const fieldConfig = { key: 'test-input', required: true, type: 'number' };
+        inputElement.value = '';
+        const isValid = validateField(fieldConfig, inputElement);
+        expect(isValid).toBe(false);
+        expect(inputElement.classList.contains('border-red-500')).toBe(true);
+        expect(errorElement.textContent).toBe('Este campo es obligatorio.');
+    });
+});


### PR DESCRIPTION
- Fixes a bug where non-numeric input in number fields was saved as NaN to Firestore.
- Enhances the `validateField` function to perform type checking on number fields, preventing invalid data submission.
- Adds a new unit test suite for the form validation logic.

Refactors the codebase for improved testability and organization:
- Moves the `validateField` function from `main.js` to `utils.js`.
- Moves the `registerEcrApproval` function from `main.js` to `data_logic.js`.
- These changes isolate business logic from UI side-effects, resolving test environment instability and allowing for proper unit testing.