### PR TITLE
Fix(ECR): Prevent disabled checkboxes from being saved to local storage

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -5,7 +5,7 @@ import { initializeApp } from "https://www.gstatic.com/firebasejs/9.15.0/firebas
 import { getAuth, onAuthStateChanged, createUserWithEmailAndPassword, signInWithEmailAndPassword, sendPasswordResetEmail, signOut, updatePassword, reauthenticateWithCredential, EmailAuthProvider, deleteUser, sendEmailVerification, updateProfile } from "https://www.gstatic.com/firebasejs/9.15.0/firebase-auth.js";
 import { getFirestore, collection, doc, getDoc, getDocs, setDoc, addDoc, updateDoc, deleteDoc, query, where, onSnapshot, writeBatch, runTransaction, orderBy, limit, startAfter, or, getCountFromServer } from "https://www.gstatic.com/firebasejs/9.15.0/firebase-firestore.js";
 import { getFunctions, httpsCallable } from "https://www.gstatic.com/firebasejs/9.15.0/firebase-functions.js";
-import { COLLECTIONS, getUniqueKeyForCollection, createHelpTooltip, shouldRequirePpapConfirmation, validateField } from './utils.js';
+import { COLLECTIONS, getUniqueKeyForCollection, createHelpTooltip, shouldRequirePpapConfirmation, validateField, saveEcrFormToLocalStorage, loadEcrFormFromLocalStorage } from './utils.js';
 import { deleteProductAndOrphanedSubProducts, registerEcrApproval } from './data_logic.js';
 import tutorial from './tutorial.js';
 import newControlPanelTutorial from './new-control-panel-tutorial.js';
@@ -4726,22 +4726,6 @@ async function runEcrFormLogic(params = null) {
     });
 
     // --- Local Storage and Data Handling ---
-    const saveEcrFormToLocalStorage = () => {
-        const formData = new FormData(formContainer);
-        const data = Object.fromEntries(formData.entries());
-        formContainer.querySelectorAll('input[type="checkbox"]').forEach(cb => {
-            data[cb.name] = cb.checked;
-        });
-        localStorage.setItem(ECR_FORM_STORAGE_KEY, JSON.stringify(data));
-    };
-
-    const loadEcrFormFromLocalStorage = () => {
-        const savedData = localStorage.getItem(ECR_FORM_STORAGE_KEY);
-        if (!savedData) return;
-        const data = JSON.parse(savedData);
-        populateEcrForm(formContainer, data);
-    };
-
     const populateEcrForm = (form, data) => {
         if (!data || !form) return;
         // Populate standard fields
@@ -4800,10 +4784,10 @@ async function runEcrFormLogic(params = null) {
     if (ecrData) {
         populateEcrForm(formContainer, ecrData);
     } else {
-        loadEcrFormFromLocalStorage();
+        loadEcrFormFromLocalStorage(formContainer, ECR_FORM_STORAGE_KEY, populateEcrForm);
     }
 
-    formContainer.addEventListener('input', saveEcrFormToLocalStorage);
+    formContainer.addEventListener('input', () => saveEcrFormToLocalStorage(formContainer, ECR_FORM_STORAGE_KEY));
 
     formContainer.addEventListener('click', async (e) => {
         const button = e.target.closest('button[data-action]');

--- a/public/utils.js
+++ b/public/utils.js
@@ -94,3 +94,32 @@ export function validateField(fieldConfig, inputElement) {
     inputElement.classList.toggle('border-gray-300', isValid);
     return isValid;
 }
+
+/**
+ * Saves ECR form data to local storage.
+ * @param {HTMLElement} formContainer - The form element.
+ * @param {string} storageKey - The key for local storage.
+ */
+export function saveEcrFormToLocalStorage(formContainer, storageKey) {
+    if (!formContainer) return;
+    const formData = new FormData(formContainer);
+    const data = Object.fromEntries(formData.entries());
+    // This is the fixed implementation.
+    formContainer.querySelectorAll('input[type="checkbox"]:not(:disabled)').forEach(cb => {
+        data[cb.name] = cb.checked;
+    });
+    localStorage.setItem(storageKey, JSON.stringify(data));
+}
+
+/**
+ * Loads ECR form data from local storage and populates the form.
+ * @param {HTMLElement} formContainer - The form element.
+ * @param {string} storageKey - The key for local storage.
+ * @param {Function} populateFormFn - The function to populate the form with data.
+ */
+export function loadEcrFormFromLocalStorage(formContainer, storageKey, populateFormFn) {
+    const savedData = localStorage.getItem(storageKey);
+    if (!savedData) return;
+    const data = JSON.parse(savedData);
+    populateFormFn(formContainer, data);
+}

--- a/tests/unit/ecr_form_localstorage.spec.js
+++ b/tests/unit/ecr_form_localstorage.spec.js
@@ -1,0 +1,75 @@
+import { describe, test, expect, beforeEach, jest } from '@jest/globals';
+import { saveEcrFormToLocalStorage } from '../../public/utils.js';
+
+// Mock localStorage
+const localStorageMock = (() => {
+    let store = {};
+    return {
+        getItem: (key) => store[key] || null,
+        setItem: (key, value) => {
+            store[key] = value.toString();
+        },
+        clear: () => {
+            store = {};
+        },
+        removeItem: (key) => {
+            delete store[key];
+        }
+    };
+})();
+Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+
+
+describe('ECR Form Local Storage Persistence', () => {
+    let formContainer;
+    const ECR_FORM_STORAGE_KEY = 'test_ecr_form_key';
+
+    beforeEach(() => {
+        // Set up a mock DOM for each test
+        document.body.innerHTML = `
+            <form id="ecr-form">
+                <input type="checkbox" name="enabled_checked" checked>
+                <input type="checkbox" name="enabled_unchecked">
+                <input type="checkbox" name="disabled_checked" checked disabled>
+                <input type="checkbox" name="disabled_unchecked" disabled>
+                <input type="text" name="text_field" value="some_value">
+            </form>
+        `;
+        formContainer = document.getElementById('ecr-form');
+        localStorage.clear();
+    });
+
+    /**
+     * This test now directly calls the refactored 'saveEcrFormToLocalStorage' function
+     * from the main application code. It verifies that the function correctly ignores
+     * disabled checkboxes when saving data.
+     *
+     * This test is designed to FAIL when the function has the bug, and PASS when it is fixed.
+     */
+    test('[BUG-VERIFY] saveEcrFormToLocalStorage should not include disabled checkboxes', () => {
+        // Spy on localStorage.setItem to see what's being saved
+        const setItemSpy = jest.spyOn(window.localStorage, 'setItem');
+
+        // Call the actual function from utils.js
+        saveEcrFormToLocalStorage(formContainer, ECR_FORM_STORAGE_KEY);
+
+        // Expect the function to have been called
+        expect(setItemSpy).toHaveBeenCalledWith(ECR_FORM_STORAGE_KEY, expect.any(String));
+
+        // Get the data that was passed to setItem
+        const savedDataJSON = setItemSpy.mock.calls[0][1];
+        const savedData = JSON.parse(savedDataJSON);
+
+        // Assert that the disabled checkboxes are NOT in the final data.
+        expect(savedData).not.toHaveProperty('disabled_checked');
+        expect(savedData).not.toHaveProperty('disabled_unchecked');
+
+        // Also confirm that the enabled checkboxes and other fields are still present.
+        expect(savedData).toHaveProperty('enabled_checked', true);
+        expect(savedData).toHaveProperty('enabled_unchecked', false);
+        expect(savedData).toHaveProperty('text_field', 'some_value');
+
+        // Clean up spy
+        setItemSpy.mockRestore();
+    });
+});


### PR DESCRIPTION
This commit fixes a bug in the ECR form where disabled checkboxes were being incorrectly persisted to local storage. This could cause UI inconsistencies when reloading a partially filled form.

The `saveEcrFormToLocalStorage` function was using a `querySelectorAll('input[type="checkbox"]')` selector, which includes disabled elements. This has been corrected to `querySelectorAll('input[type="checkbox"]:not(:disabled)')` to ensure only user-interactable elements are saved.

Additionally, the persistence logic (`saveEcrFormToLocalStorage` and `loadEcrFormFromLocalStorage`) has been refactored from `main.js` into the more appropriate `utils.js` and exported to make it directly testable.

A new unit test has been added to verify this specific fix and prevent regressions.