### PR TITLE
fix(form): Fix ECR validation and migrate saving to client

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -4966,6 +4966,11 @@ async function runEcrFormLogic(params = null) {
         ];
 
         requiredFields.forEach(field => {
+            // Skip ecr_no validation if creating a new ECR
+            if (field.name === 'ecr_no' && !isEditing) {
+                return;
+            }
+
             const input = formContainer.querySelector(`[name="${field.name}"]`);
             if (input && !input.value.trim()) {
                 isValid = false;


### PR DESCRIPTION
Migrates form saving logic from a non-existent Cloud Function to the client-side for both ECO and ECR forms. This resolves the network/CORS errors.

Corrects a regression in the ECR form where a new form could not be saved due to a validation deadlock on the 'ECR N°' field.

The validation for 'ECR N°' is now conditional and only applies when editing an existing ECR.