### PR TITLE
Fix TypeError in ECO form when associating an ECR

### DIFF
--- a/jules-scratch/verification/verify_ecr_association.py
+++ b/jules-scratch/verification/verify_ecr_association.py
@@ -1,0 +1,68 @@
+import asyncio
+import re
+from playwright.async_api import async_playwright, expect
+
+async def main():
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        page = await browser.new_page()
+
+        await page.goto("http://localhost:8080")
+
+        # Login
+        await page.locator("#login-panel").get_by_label("Correo electrónico").fill("f.santoro@barackmercosul.com")
+        await page.locator("#login-panel").get_by_label("Contraseña").fill("$oof@k24")
+        await page.get_by_role("button", name="Iniciar Sesión").click()
+
+        # Wait for dashboard to load
+        await expect(page.get_by_role("heading", name="Dashboard de Control")).to_be_visible(timeout=30000)
+
+        # Create a dummy ECR first
+        await page.get_by_role("button", name="ECR/ECO").click()
+        await page.get_by_role("link", name="ECR", exact=True).click()
+        await page.get_by_role("button", name="Crear Nuevo ECR").click()
+
+        # Open product search
+        await page.locator('button[data-action="open-ecr-product-search"]').click()
+
+        # Wait for modal and select the first product
+        await expect(page.get_by_role("heading", name="Buscar Producto")).to_be_visible()
+        await page.locator('button[data-product-id]').first.click()
+
+        # Fill out the rest of the ECR form
+        await page.locator("textarea[name='situacion_existente']").fill("test")
+        await page.locator("textarea[name='situacion_propuesta']").fill("test")
+
+        await page.get_by_role("button", name="Aprobar y Guardar").click()
+        await page.get_by_role("button", name=re.compile(r"Confirmar", re.IGNORECASE)).click()
+
+        # Wait for the ECR to be saved
+        await expect(page.get_by_text("ECR guardado con éxito.")).to_be_visible()
+        await page.wait_for_timeout(1000) # Wait a bit for UI to settle
+
+        await expect(page.get_by_role("heading", name="Planilla General de ECR")).to_be_visible()
+
+        # Navigate to ECO management
+        await page.get_by_role("button", name="ECR/ECO").click()
+        await page.get_by_role("link", name="Gestión de ECO").click()
+
+        await expect(page.get_by_role("heading", name="Planilla General de ECO")).to_be_visible()
+
+        # Create a new ECO
+        await page.get_by_role("button", name="Crear Nuevo ECO").click()
+
+        await expect(page.get_by_role("heading", name="ECR Asociado:")).to_be_visible()
+
+        # Click the search button to associate ECR
+        await page.locator('button[data-action="open-ecr-search-for-eco"]').click()
+
+        # Wait for the modal to appear
+        await expect(page.get_by_role("heading", name="Seleccionar ECR Aprobado")).to_be_visible()
+
+        # Take a screenshot of the modal
+        await page.screenshot(path="jules-scratch/verification/ecr_association_modal.png")
+
+        await browser.close()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/public/main.js
+++ b/public/main.js
@@ -1965,10 +1965,10 @@ async function runEcoFormLogic(params = null) {
         // Add event listener to save on any input
         formElement.addEventListener('input', saveEcoFormToLocalStorage);
 
-        formElement.addEventListener('click', (e) => {
+        formElement.addEventListener('click', async (e) => {
             const button = e.target.closest('button[data-action="open-ecr-search-for-eco"]');
             if (button) {
-                openEcrSearchModalForEcoForm();
+                await openEcrSearchModalForEcoForm();
             }
         });
 
@@ -4174,7 +4174,15 @@ function openEcrProductSearchModal() {
     searchHandler(); // Initial render
 }
 
-function openEcrSearchModalForEcoForm() {
+async function openEcrSearchModalForEcoForm() {
+    // Ensure the ECR collection is loaded before proceeding.
+    try {
+        await ensureCollectionsAreLoaded([COLLECTIONS.ECR_FORMS]);
+    } catch (error) {
+        showToast('Error al cargar la lista de ECRs. Intente de nuevo.', 'error');
+        return;
+    }
+
     const modalId = `ecr-search-for-eco-modal-${Date.now()}`;
     const modalHTML = `
         <div id="${modalId}" class="fixed inset-0 z-[60] flex items-center justify-center modal-backdrop animate-fade-in">


### PR DESCRIPTION
The function `openEcrSearchModalForEcoForm` was throwing a TypeError because it was trying to filter the `ECR_FORMS` collection before it was loaded from Firestore.

This commit fixes the issue by:
1. Making `openEcrSearchModalForEcoForm` an async function.
2. Calling the existing `ensureCollectionsAreLoaded` helper to fetch the ECR data before it is accessed.
3. Updating the calling event listener in `runEcoFormLogic` to be async and await the function call.

This ensures the data is always available, preventing the crash and allowing the user to correctly associate an ECO with an ECR.