### PR TITLE
fix(eco-form): Correctly position 'ECR Asociado' field

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -1525,11 +1525,11 @@ async function runEcoFormLogic(params = null) {
         formElement.id = 'eco-form';
         formElement.className = 'max-w-7xl mx-auto bg-white shadow-lg rounded-lg p-8';
         formElement.innerHTML = `
-            <header class="flex justify-between items-center border-b-2 pb-4 mb-6" style="background-color: #eee;">
+            <header class="flex justify-between items-center border-b-2 pb-4 mb-6">
                 <div class="flex-shrink-0">
                     <img src="/barack_logo.png" alt="Logo" class="h-12">
                 </div>
-                <div style="margin-left: auto; border: 2px solid red; padding: 5px;">
+                <div class="ml-auto">
                     <div class="form-field">
                         <label for="ecr_no_display" class="text-lg font-semibold">ECR Asociado:</label>
                         <div class="flex items-center gap-2 mt-1">


### PR DESCRIPTION
This commit permanently fixes the layout of the 'ECR Asociado' field in the ECO form header.

The field is now wrapped in a container with the `ml-auto` utility class, which robustly pushes it to the far right of the header, ensuring proper alignment and separation from the logo, as per the user's request.

This change supersedes previous attempts and diagnostic commits, providing a clean and final solution to the layout issue.