### PR TITLE
Chore: Clean up obsolete and misleading test descriptions

### DIFF
--- a/tests/unit/data_logic.spec.js
+++ b/tests/unit/data_logic.spec.js
@@ -299,7 +299,7 @@ describe('deleteProductAndOrphanedSubProducts', () => {
         expect(mockUiCallbacks.runTableLogic).toHaveBeenCalled();
     });
 
-    test('[New Failing Test] should correctly identify and delete an orphan when it is only used by the product being deleted', async () => {
+    test('should correctly identify and delete an orphan when it is only used by the product being deleted', async () => {
         // Arrange
         const productToDeleteId = 'PROD_A';
         const productToDeleteData = {
@@ -338,9 +338,7 @@ describe('deleteProductAndOrphanedSubProducts', () => {
         await deleteProductAndOrphanedSubProducts(productToDeleteId, mockDb, mockFirestore, COLLECTIONS, mockUiCallbacks);
 
         // Assert
-        // The bug is that `deleteDoc` is only called once (for the main product) because it incorrectly
-        // finds the orphan in use by the product being deleted.
-        // A correct implementation should call it TWICE.
+        // A correct implementation should call deleteDoc twice: once for the product, once for the orphan.
         expect(mockFirestore.deleteDoc).toHaveBeenCalledTimes(2);
 
         // Verify it was called for the orphan

--- a/tests/unit/ecr_approval.spec.js
+++ b/tests/unit/ecr_approval.spec.js
@@ -56,7 +56,7 @@ describe('registerEcrApproval State Machine', () => {
         });
     });
 
-    test('[BUG-REPRO] should transition ECR status to "approved" when the last required department approves', async () => {
+    test('should transition ECR status to "approved" when the last required department approves', async () => {
         // --- 1. ARRANGE ---
         const ecrId = 'ECR-BUG-001';
         const initialEcrData = {
@@ -94,7 +94,7 @@ describe('registerEcrApproval State Machine', () => {
 
         expect(updateCallArgs['approvals.compras'].status).toBe('approved');
 
-        // This is the assertion that is expected to fail.
+        // The overall status should now be 'approved' as all required departments have approved.
         expect(updateCallArgs.status).toBe('approved');
     });
 


### PR DESCRIPTION
This commit removes misleading prefixes like `[BUG-REPRO]` and `[New Failing Test]` from test names in `data_logic.spec.js` and `ecr_approval.spec.js`.

Upon investigation, the bugs that these tests were originally written for had already been fixed in the application code, but the test names and comments were not updated. This created confusion, making it appear that the tests were intended to fail.

By renaming the tests and updating the comments to reflect their current purpose (i.e., as passing regression tests), this change improves the clarity and maintainability of the test suite, preventing future developers from wasting time investigating non-existent bugs.