### PR TITLE
Fix(clone): Ensure unique node IDs during product cloning

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -10965,7 +10965,29 @@ function exportSinopticoPdf(activeFilters) {
 // --- LÓGICA DE CLONACIÓN Y MODALES ESPECIALES ---
 // =================================================================================
 
-async function cloneProduct() {
+/**
+ * Recursively traverses a node tree and assigns new, unique IDs to each node.
+ * This function is exported for testing purposes.
+ * @param {Array} nodes - The array of root nodes of the structure to process.
+ * @returns {void} - The function modifies the nodes in place.
+ */
+export function regenerateNodeIds(nodes) {
+    if (!nodes) return;
+    let counter = 0;
+    const timestamp = Date.now();
+
+    function processNodes(nodeArray) {
+        nodeArray.forEach(node => {
+            node.id = `comp_${timestamp}_${counter++}`;
+            if (node.children) {
+                processNodes(node.children);
+            }
+        });
+    }
+    processNodes(nodes);
+}
+
+export async function cloneProduct() {
     const productToClone = appState.sinopticoTabularState.selectedProduct;
     if (!productToClone) {
         showToast('No hay un producto seleccionado para clonar.', 'error');
@@ -10995,17 +11017,6 @@ async function cloneProduct() {
     delete newProduct.reviewedBy;
     newProduct.id = newId;
     newProduct.createdAt = new Date();
-
-    // Generate new unique IDs for all nodes in the structure
-    function regenerateNodeIds(nodes) {
-        if (!nodes) return;
-        nodes.forEach(node => {
-            node.id = `comp_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
-            if (node.children) {
-                regenerateNodeIds(node.children);
-            }
-        });
-    }
 
     if (newProduct.estructura) {
         regenerateNodeIds(newProduct.estructura);

--- a/tests/unit/clone_product_bug.spec.js
+++ b/tests/unit/clone_product_bug.spec.js
@@ -1,0 +1,66 @@
+import { jest, describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import { regenerateNodeIds } from '../../public/main.js';
+
+describe('regenerateNodeIds Function', () => {
+
+    const getIds = (nodes) => {
+        let ids = [];
+        if (!nodes) return ids;
+        nodes.forEach(node => {
+            ids.push(node.id);
+            if (node.children) {
+                ids = ids.concat(getIds(node.children));
+            }
+        });
+        return ids;
+    };
+
+    test('[FIX] should generate unique IDs for all nodes in a tree structure', () => {
+        // --- ARRANGE ---
+        // Create a deep copy of a sample node tree for the function to mutate
+        const mockNodeTree = [
+            { id: 'old-1', children: [
+                { id: 'old-2', children: [] },
+                { id: 'old-3', children: [] }
+            ]},
+            { id: 'old-4', children: [] }
+        ];
+
+        // --- ACT ---
+        // Call the function, which will modify the mockNodeTree in place
+        regenerateNodeIds(mockNodeTree);
+
+        // --- ASSERT ---
+        // 1. Get all the new IDs from the mutated tree
+        const allGeneratedIds = getIds(mockNodeTree);
+        const totalIds = allGeneratedIds.length;
+
+        // 2. Check for uniqueness
+        const uniqueIds = new Set(allGeneratedIds);
+
+        // 3. The number of unique IDs must equal the total number of nodes
+        expect(uniqueIds.size).toBe(totalIds);
+        expect(totalIds).toBe(4); // Ensure we processed the whole tree
+
+        // 4. Check that old IDs are gone
+        expect(uniqueIds.has('old-1')).toBe(false);
+    });
+
+    test('should handle empty or null input without crashing', () => {
+        expect(() => regenerateNodeIds(null)).not.toThrow();
+        expect(() => regenerateNodeIds(undefined)).not.toThrow();
+        expect(() => regenerateNodeIds([])).not.toThrow();
+    });
+
+    test('should generate different IDs on subsequent calls', () => {
+        const tree1 = [{ id: 'a' }];
+        const tree2 = [{ id: 'b' }];
+
+        regenerateNodeIds(tree1);
+        // A small delay to ensure Date.now() will be different
+        setTimeout(() => {
+            regenerateNodeIds(tree2);
+            expect(tree1[0].id).not.toEqual(tree2[0].id);
+        }, 10);
+    });
+});


### PR DESCRIPTION
The `regenerateNodeIds` helper function within `cloneProduct` used a combination of `Date.now()` and `Math.random()` to generate new node IDs. This method is not guaranteed to be unique, especially in a fast loop where `Date.now()` could return the same value for multiple nodes.

This change refactors the ID generation logic to use a timestamp combined with an incrementing counter. This guarantees that all nodes within a single cloning operation will receive a unique ID, preventing potential UI bugs caused by ID collisions.

The `regenerateNodeIds` function has also been extracted from `cloneProduct` and exported to make it independently testable. A new test suite has been added to verify the correctness of the new implementation.