### PR TITLE
refactor(functions): Use process.env for environment variables

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -148,8 +148,8 @@ exports.enviarRecordatoriosDiarios = functions.pubsub.schedule("every day 09:00"
   .onRun(async (context) => {
     console.log("Ejecutando la revisión de recordatorios diarios.");
 
-    const telegramToken = functions.config().telegram.token;
-    const chatId = functions.config().telegram.chat_id;
+    const telegramToken = process.env.TELEGRAM_TOKEN;
+    const chatId = process.env.TELEGRAM_CHAT_ID;
 
     if (!telegramToken || !chatId) {
         console.log("Telegram token or chat ID not set.");


### PR DESCRIPTION
This commit refactors the `enviarRecordatoriosDiarios` function to use `process.env` for accessing environment variables instead of the deprecated `functions.config()`.

This change allows for setting secrets at deployment time via the `--set-env-vars` flag, avoiding the need to enable a billing account to use the Secret Manager API. This directly addresses the user's request for a solution that works on the Firebase Spark (free) plan without a billing account attached.

The function now expects `TELEGRAM_TOKEN` and `TELEGRAM_CHAT_ID` to be present in the process environment.